### PR TITLE
Fix actor isolation crash in fetchReminders

### DIFF
--- a/Sources/RemindCore/EventKitStore.swift
+++ b/Sources/RemindCore/EventKitStore.swift
@@ -204,11 +204,24 @@ public actor RemindersStore {
   }
 
   private func fetchReminders(in calendars: [EKCalendar]) async -> [ReminderItem] {
-    await withCheckedContinuation { continuation in
+    // Capture calendar for use in closure (avoids actor isolation issues)
+    let cal = self.calendar
+    return await withCheckedContinuation { continuation in
       let predicate = eventStore.predicateForReminders(in: calendars)
       eventStore.fetchReminders(matching: predicate) { reminders in
+        // Extract all data from EKReminder objects here, before crossing isolation boundary
         let mapped = (reminders ?? []).map { reminder in
-          self.item(from: reminder)
+          ReminderItem(
+            id: reminder.calendarItemIdentifier,
+            title: reminder.title ?? "",
+            notes: reminder.notes,
+            isCompleted: reminder.isCompleted,
+            completionDate: reminder.completionDate,
+            priority: ReminderPriority(eventKitValue: Int(reminder.priority)),
+            dueDate: reminder.dueDateComponents.flatMap { cal.date(from: $0) },
+            listID: reminder.calendar.calendarIdentifier,
+            listName: reminder.calendar.title
+          )
         }
         continuation.resume(returning: mapped)
       }


### PR DESCRIPTION
## Problem

Running `remindctl list` crashes with:
```
Incorrect actor executor assumption; expected 'RemindCore.RemindersStore' executor.
Abort trap: 6
```

## Cause

The `fetchReminders` method calls `self.item(from:)` inside the EventKit callback closure. This callback runs on EventKit's executor, not the actor's executor, causing Swift's strict concurrency checking to abort.

## Fix

Extract all data from `EKReminder` objects directly within the callback closure before the data crosses the isolation boundary. The `calendar` property is captured beforehand to avoid accessing actor-isolated state from within the closure.

## Testing

Tested on macOS 15 (Sequoia) with Swift 6:
- `remindctl list` ✅
- `remindctl list "List Name"` ✅  
- `remindctl add` ✅
- `remindctl delete` ✅