### PR TITLE
Add creationDate to JSON output

### DIFF
--- a/Sources/RemindCore/EventKitStore.swift
+++ b/Sources/RemindCore/EventKitStore.swift
@@ -110,6 +110,7 @@ public actor RemindersStore {
       notes: reminder.notes,
       isCompleted: reminder.isCompleted,
       completionDate: reminder.completionDate,
+      creationDate: reminder.creationDate,
       priority: ReminderPriority(eventKitValue: Int(reminder.priority)),
       dueDate: date(from: reminder.dueDateComponents),
       listID: reminder.calendar.calendarIdentifier,
@@ -151,6 +152,7 @@ public actor RemindersStore {
       notes: reminder.notes,
       isCompleted: reminder.isCompleted,
       completionDate: reminder.completionDate,
+      creationDate: reminder.creationDate,
       priority: ReminderPriority(eventKitValue: Int(reminder.priority)),
       dueDate: date(from: reminder.dueDateComponents),
       listID: reminder.calendar.calendarIdentifier,
@@ -171,6 +173,7 @@ public actor RemindersStore {
           notes: reminder.notes,
           isCompleted: reminder.isCompleted,
           completionDate: reminder.completionDate,
+          creationDate: reminder.creationDate,
           priority: ReminderPriority(eventKitValue: Int(reminder.priority)),
           dueDate: date(from: reminder.dueDateComponents),
           listID: reminder.calendar.calendarIdentifier,
@@ -210,6 +213,7 @@ public actor RemindersStore {
       let notes: String?
       let isCompleted: Bool
       let completionDate: Date?
+      let creationDate: Date?
       let priority: Int
       let dueDateComponents: DateComponents?
       let listID: String
@@ -226,6 +230,7 @@ public actor RemindersStore {
             notes: reminder.notes,
             isCompleted: reminder.isCompleted,
             completionDate: reminder.completionDate,
+            creationDate: reminder.creationDate,
             priority: Int(reminder.priority),
             dueDateComponents: reminder.dueDateComponents,
             listID: reminder.calendar.calendarIdentifier,
@@ -243,6 +248,7 @@ public actor RemindersStore {
         notes: data.notes,
         isCompleted: data.isCompleted,
         completionDate: data.completionDate,
+        creationDate: data.creationDate,
         priority: ReminderPriority(eventKitValue: data.priority),
         dueDate: date(from: data.dueDateComponents),
         listID: data.listID,
@@ -282,6 +288,7 @@ public actor RemindersStore {
       notes: reminder.notes,
       isCompleted: reminder.isCompleted,
       completionDate: reminder.completionDate,
+      creationDate: reminder.creationDate,
       priority: ReminderPriority(eventKitValue: Int(reminder.priority)),
       dueDate: date(from: reminder.dueDateComponents),
       listID: reminder.calendar.calendarIdentifier,

--- a/Sources/RemindCore/Models.swift
+++ b/Sources/RemindCore/Models.swift
@@ -49,6 +49,7 @@ public struct ReminderItem: Identifiable, Codable, Sendable, Equatable {
   public let notes: String?
   public let isCompleted: Bool
   public let completionDate: Date?
+  public let creationDate: Date?
   public let priority: ReminderPriority
   public let dueDate: Date?
   public let listID: String
@@ -60,6 +61,7 @@ public struct ReminderItem: Identifiable, Codable, Sendable, Equatable {
     notes: String?,
     isCompleted: Bool,
     completionDate: Date?,
+    creationDate: Date?,
     priority: ReminderPriority,
     dueDate: Date?,
     listID: String,
@@ -70,6 +72,7 @@ public struct ReminderItem: Identifiable, Codable, Sendable, Equatable {
     self.notes = notes
     self.isCompleted = isCompleted
     self.completionDate = completionDate
+    self.creationDate = creationDate
     self.priority = priority
     self.dueDate = dueDate
     self.listID = listID


### PR DESCRIPTION
The underlying EventKit API exposes `creationDate` on `EKCalendarItem` (which `EKReminder` inherits). This change includes it in the `ReminderItem` model so it appears in JSON output.

This is useful for automation that needs to know when a reminder was originally created (e.g., filtering 'recently created' items).

## Changes
- Added `creationDate: Date?` to `ReminderItem` struct
- Updated all `ReminderItem` constructors to include `creationDate`
- Updated `ReminderData` (the `Sendable` transfer struct) to include it

## Testing
- Build passes
- Verified JSON output now includes `creationDate` field