### PR TITLE
feat: add location-based reminder triggers

### DIFF
--- a/Sources/RemindCore/Models.swift
+++ b/Sources/RemindCore/Models.swift
@@ -77,17 +77,52 @@ public struct ReminderItem: Identifiable, Codable, Sendable, Equatable {
   }
 }
 
+public enum LocationProximity: String, Codable, CaseIterable, Sendable {
+  case arriving = "arriving"
+  case leaving = "leaving"
+}
+
+public struct LocationTrigger: Sendable {
+  public let address: String
+  public let latitude: Double?
+  public let longitude: Double?
+  public let radius: Double  // in meters
+  public let proximity: LocationProximity
+
+  public init(
+    address: String,
+    latitude: Double? = nil,
+    longitude: Double? = nil,
+    radius: Double = 100,
+    proximity: LocationProximity = .arriving
+  ) {
+    self.address = address
+    self.latitude = latitude
+    self.longitude = longitude
+    self.radius = radius
+    self.proximity = proximity
+  }
+}
+
 public struct ReminderDraft: Sendable {
   public let title: String
   public let notes: String?
   public let dueDate: Date?
   public let priority: ReminderPriority
+  public let location: LocationTrigger?
 
-  public init(title: String, notes: String?, dueDate: Date?, priority: ReminderPriority) {
+  public init(
+    title: String,
+    notes: String?,
+    dueDate: Date?,
+    priority: ReminderPriority,
+    location: LocationTrigger? = nil
+  ) {
     self.title = title
     self.notes = notes
     self.dueDate = dueDate
     self.priority = priority
+    self.location = location
   }
 }
 


### PR DESCRIPTION
Adds support for location-based (geofence) reminder triggers via new flags:

- `--location <address>`: Address string that gets geocoded to coordinates
- `--leaving`: Trigger when leaving location (default: trigger on arriving)
- `--radius <meters>`: Geofence radius in meters (default: 100)

## Examples

```bash
# Trigger when arriving at an address
remindctl add "Check mailbox" --location "50 West St, New York, NY"

# Trigger when leaving
remindctl add "Lock up" --location "Home" --leaving

# Custom radius
remindctl add "Get groceries" --location "123 Main St" --radius 200
```

## Implementation

- Added `LocationTrigger` and `LocationProximity` types to Models.swift
- Added `createLocationAlarm` to EventKitStore.swift using `EKStructuredLocation` and `CLGeocoder`
- Added flags to AddCommand.swift

Closes the gap for CLI-based location reminders that previously required the Reminders app GUI.