### PR TITLE
feat: expose Reminders sections in output

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
       dependencies: [],
       linkerSettings: [
         .linkedFramework("EventKit"),
+        .linkedLibrary("sqlite3"),
       ]
     ),
     .executableTarget(

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ remindctl authorize             # request permissions
 - `--json` emits JSON arrays/objects.
 - `--plain` emits tab-separated lines.
 - `--quiet` emits counts only.
+- Section names are best-effort metadata from the local Reminders store; section ordering is not currently exposed.
 
 ## Date formats
 Accepted by `--due` and filters:

--- a/Sources/RemindCore/Models.swift
+++ b/Sources/RemindCore/Models.swift
@@ -53,6 +53,7 @@ public struct ReminderItem: Identifiable, Codable, Sendable, Equatable {
   public let dueDate: Date?
   public let listID: String
   public let listName: String
+  public let sectionName: String?
 
   public init(
     id: String,
@@ -63,7 +64,8 @@ public struct ReminderItem: Identifiable, Codable, Sendable, Equatable {
     priority: ReminderPriority,
     dueDate: Date?,
     listID: String,
-    listName: String
+    listName: String,
+    sectionName: String? = nil
   ) {
     self.id = id
     self.title = title
@@ -74,6 +76,7 @@ public struct ReminderItem: Identifiable, Codable, Sendable, Equatable {
     self.dueDate = dueDate
     self.listID = listID
     self.listName = listName
+    self.sectionName = sectionName
   }
 }
 
@@ -83,7 +86,12 @@ public struct ReminderDraft: Sendable {
   public let dueDate: Date?
   public let priority: ReminderPriority
 
-  public init(title: String, notes: String?, dueDate: Date?, priority: ReminderPriority) {
+  public init(
+    title: String,
+    notes: String?,
+    dueDate: Date?,
+    priority: ReminderPriority
+  ) {
     self.title = title
     self.notes = notes
     self.dueDate = dueDate

--- a/Sources/RemindCore/SectionResolver.swift
+++ b/Sources/RemindCore/SectionResolver.swift
@@ -1,0 +1,128 @@
+import Foundation
+import SQLite3
+
+/// Reads section data from the Reminders CoreData SQLite store.
+/// Degrades gracefully (returns empty map) when the database is unavailable.
+public enum SectionResolver {
+
+  /// Builds a mapping of EventKit calendarItemIdentifier → section display name.
+  /// Opens the database read-only; returns `[:]` on any failure.
+  public static func resolve() -> [String: String] {
+    guard let dbPath = findDatabase() else { return [:] }
+    var db: OpaquePointer?
+    guard sqlite3_open_v2(dbPath, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, nil) == SQLITE_OK else {
+      return [:]
+    }
+    defer { sqlite3_close(db) }
+
+    let sections = querySections(db: db!)
+    if sections.isEmpty { return [:] }
+
+    let reminderMap = queryReminderIdentifiers(db: db!)
+    let memberships = queryMemberships(db: db!)
+
+    var result: [String: String] = [:]
+    for (reminderCK, sectionCK) in memberships {
+      guard let sectionName = sections[sectionCK],
+        let ekID = reminderMap[reminderCK]
+      else { continue }
+      result[ekID] = sectionName
+    }
+    return result
+  }
+
+  // MARK: - Private
+
+  private static func findDatabase() -> String? {
+    let home = FileManager.default.homeDirectoryForCurrentUser.path
+    let storesDir =
+      "\(home)/Library/Group Containers/group.com.apple.reminders/Container_v1/Stores"
+
+    guard let contents = try? FileManager.default.contentsOfDirectory(atPath: storesDir) else {
+      return nil
+    }
+    for file in contents where file.hasSuffix(".sqlite") {
+      let path = "\(storesDir)/\(file)"
+      if FileManager.default.isReadableFile(atPath: path) {
+        return path
+      }
+    }
+    return nil
+  }
+
+  /// Section CK identifier → display name.
+  private static func querySections(db: OpaquePointer) -> [String: String] {
+    let sql = "SELECT ZCKIDENTIFIER, ZDISPLAYNAME FROM ZREMCDBASESECTION"
+    var stmt: OpaquePointer?
+    guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return [:] }
+    defer { sqlite3_finalize(stmt) }
+
+    var map: [String: String] = [:]
+    while sqlite3_step(stmt) == SQLITE_ROW {
+      guard let ckRaw = sqlite3_column_text(stmt, 0),
+        let nameRaw = sqlite3_column_text(stmt, 1)
+      else { continue }
+      let ck = String(cString: ckRaw)
+      let name = String(cString: nameRaw)
+      map[ck] = name
+    }
+    return map
+  }
+
+  /// Reminder CK identifier → EventKit calendarItemIdentifier.
+  private static func queryReminderIdentifiers(db: OpaquePointer) -> [String: String] {
+    let sql = """
+      SELECT ZCKIDENTIFIER, ZDACALENDARITEMUNIQUEIDENTIFIER \
+      FROM ZREMCDREMINDER \
+      WHERE ZDACALENDARITEMUNIQUEIDENTIFIER IS NOT NULL
+      """
+    var stmt: OpaquePointer?
+    guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return [:] }
+    defer { sqlite3_finalize(stmt) }
+
+    var map: [String: String] = [:]
+    while sqlite3_step(stmt) == SQLITE_ROW {
+      guard let ckRaw = sqlite3_column_text(stmt, 0),
+        let ekRaw = sqlite3_column_text(stmt, 1)
+      else { continue }
+      let ck = String(cString: ckRaw)
+      let ek = String(cString: ekRaw)
+      map[ck] = ek
+    }
+    return map
+  }
+
+  /// Reminder CK identifier → section CK identifier (from membership JSON blobs on lists).
+  private static func queryMemberships(db: OpaquePointer) -> [String: String] {
+    let sql = """
+      SELECT ZMEMBERSHIPSOFREMINDERSINSECTIONSASDATA \
+      FROM ZREMCDBASELIST \
+      WHERE ZMEMBERSHIPSOFREMINDERSINSECTIONSASDATA IS NOT NULL
+      """
+    var stmt: OpaquePointer?
+    guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return [:] }
+    defer { sqlite3_finalize(stmt) }
+
+    var map: [String: String] = [:]
+    while sqlite3_step(stmt) == SQLITE_ROW {
+      guard let blob = sqlite3_column_blob(stmt, 0) else { continue }
+      let length = Int(sqlite3_column_bytes(stmt, 0))
+      let data = Data(bytes: blob, count: length)
+      parseMembershipBlob(data, into: &map)
+    }
+    return map
+  }
+
+  private static func parseMembershipBlob(_ data: Data, into map: inout [String: String]) {
+    guard
+      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      let memberships = json["memberships"] as? [[String: Any]]
+    else { return }
+    for entry in memberships {
+      guard let memberID = entry["memberID"] as? String,
+        let groupID = entry["groupID"] as? String
+      else { continue }
+      map[memberID] = groupID
+    }
+  }
+}

--- a/Sources/remindctl/OutputFormatting.swift
+++ b/Sources/remindctl/OutputFormatting.swift
@@ -51,7 +51,8 @@ enum OutputRenderer {
     switch format {
     case .standard:
       let due = reminder.dueDate.map { DateParsing.formatDisplay($0) } ?? "no due date"
-      Swift.print("✓ \(reminder.title) [\(reminder.listName)] — \(due)")
+      let listLabel = listLabel(for: reminder)
+      Swift.print("✓ \(reminder.title) [\(listLabel)] — \(due)")
     case .plain:
       Swift.print(plainLine(for: reminder))
     case .json:
@@ -98,7 +99,8 @@ enum OutputRenderer {
       let status = reminder.isCompleted ? "x" : " "
       let due = reminder.dueDate.map { DateParsing.formatDisplay($0) } ?? "no due date"
       let priority = reminder.priority == .none ? "" : " priority=\(reminder.priority.rawValue)"
-      Swift.print("[\(index + 1)] [\(status)] \(reminder.title) [\(reminder.listName)] — \(due)\(priority)")
+      let listLabel = listLabel(for: reminder)
+      Swift.print("[\(index + 1)] [\(status)] \(reminder.title) [\(listLabel)] — \(due)\(priority)")
     }
   }
 
@@ -114,6 +116,7 @@ enum OutputRenderer {
     return [
       reminder.id,
       reminder.listName,
+      reminder.sectionName ?? "",
       reminder.isCompleted ? "1" : "0",
       reminder.priority.rawValue,
       due,
@@ -150,6 +153,13 @@ enum OutputRenderer {
     } catch {
       Swift.print("Failed to encode JSON: \(error)")
     }
+  }
+
+  private static func listLabel(for reminder: ReminderItem) -> String {
+    if let section = reminder.sectionName {
+      return "\(reminder.listName)/\(section)"
+    }
+    return reminder.listName
   }
 
   private static func isoFormatter() -> ISO8601DateFormatter {

--- a/Tests/RemindCoreTests/SectionResolverTests.swift
+++ b/Tests/RemindCoreTests/SectionResolverTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+
+@testable import RemindCore
+
+@MainActor
+struct SectionResolverTests {
+  @Test("Prefers newest readable Data-*.sqlite store")
+  func picksNewestDataStore() throws {
+    let fileManager = FileManager.default
+    let tempRoot = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    defer { try? fileManager.removeItem(at: tempRoot) }
+
+    let staleStore = tempRoot.appendingPathComponent("Data-stale.sqlite")
+    let freshStore = tempRoot.appendingPathComponent("Data-fresh.sqlite")
+    let fallbackStore = tempRoot.appendingPathComponent("Fallback.sqlite")
+
+    fileManager.createFile(atPath: staleStore.path, contents: Data())
+    fileManager.createFile(atPath: freshStore.path, contents: Data())
+    fileManager.createFile(atPath: fallbackStore.path, contents: Data())
+
+    let oldDate = Date(timeIntervalSince1970: 1_700_000_000)
+    let newDate = Date(timeIntervalSince1970: 1_800_000_000)
+    try fileManager.setAttributes([.modificationDate: oldDate], ofItemAtPath: staleStore.path)
+    try fileManager.setAttributes([.modificationDate: newDate], ofItemAtPath: freshStore.path)
+
+    let selected = SectionResolver.newestReadableDataStore(in: tempRoot.path)
+    #expect(selected == freshStore.path)
+  }
+}


### PR DESCRIPTION
## Summary

Closes #14.

- Add read-only support for Apple Reminders **sections** (custom groupings within a list) by reading the Reminders CoreData SQLite store directly, since EventKit does not expose section data.
- Surface `sectionName` as an optional field on `ReminderItem` — appears in JSON, plain, and standard output formats (e.g. `[Books/Non-fiction]`).
- Refactor `EventKitStore` to use a shared `item(from:)` helper, removing four duplicate `ReminderItem` construction sites.

## Details

`SectionResolver` opens the Reminders SQLite database read-only and joins three tables (`ZREMCDBASESECTION`, `ZREMCDREMINDER`, `ZREMCDBASELIST`) to build an EventKit calendarItemIdentifier → section display name map. It degrades gracefully to an empty map when the database is unavailable or unreadable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)