### PR TITLE
feat: add `open` filter to show all incomplete reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ remindctl tomorrow              # show tomorrow
 remindctl week                  # show this week
 remindctl overdue               # overdue
 remindctl upcoming              # upcoming
+remindctl open                  # all incomplete reminders
 remindctl completed             # completed
 remindctl all                   # all reminders
 remindctl 2026-01-03            # specific date

--- a/Sources/RemindCore/ReminderFilter.swift
+++ b/Sources/RemindCore/ReminderFilter.swift
@@ -6,6 +6,7 @@ public enum ReminderFilter: Equatable, Sendable {
   case week
   case overdue
   case upcoming
+  case open
   case completed
   case date(Date)
   case all
@@ -25,6 +26,8 @@ public enum ReminderFiltering {
       return .overdue
     case "upcoming", "u":
       return .upcoming
+    case "open":
+      return .open
     case "completed", "done", "c":
       return .completed
     case "all", "a":
@@ -76,6 +79,8 @@ public enum ReminderFiltering {
       return reminders.filter { reminder in
         !reminder.isCompleted && reminder.dueDate != nil
       }
+    case .open:
+      return reminders.filter { !$0.isCompleted }
     case .completed:
       return reminders.filter { $0.isCompleted }
     case .date(let date):

--- a/Sources/remindctl/Commands/ShowCommand.swift
+++ b/Sources/remindctl/Commands/ShowCommand.swift
@@ -7,13 +7,13 @@ enum ShowCommand {
     CommandSpec(
       name: "show",
       abstract: "Show reminders",
-      discussion: "Filters: today, tomorrow, week, overdue, upcoming, completed, all, or a date string.",
+      discussion: "Filters: today, tomorrow, week, overdue, upcoming, open, completed, all, or a date string.",
       signature: CommandSignatures.withRuntimeFlags(
         CommandSignature(
           arguments: [
             .make(
               label: "filter",
-              help: "today|tomorrow|week|overdue|upcoming|completed|all|<date>",
+              help: "today|tomorrow|week|overdue|upcoming|open|completed|all|<date>",
               isOptional: true
             )
           ],

--- a/Tests/RemindCoreTests/ReminderFilterParseTests.swift
+++ b/Tests/RemindCoreTests/ReminderFilterParseTests.swift
@@ -10,6 +10,7 @@ struct ReminderFilterParseTests {
     #expect(ReminderFiltering.parse("w") == .week)
     #expect(ReminderFiltering.parse("o") == .overdue)
     #expect(ReminderFiltering.parse("u") == .upcoming)
+    #expect(ReminderFiltering.parse("open") == .open)
     #expect(ReminderFiltering.parse("done") == .completed)
     #expect(ReminderFiltering.parse("all") == .all)
   }

--- a/Tests/RemindCoreTests/ReminderFilteringTests.swift
+++ b/Tests/RemindCoreTests/ReminderFilteringTests.swift
@@ -108,6 +108,16 @@ struct ReminderFilteringTests {
     #expect(result.count == 3)
   }
 
+  @Test("Open filter includes no due date and excludes completed")
+  func openFilter() {
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+    let items = reminders(now: now)
+    let result = ReminderFiltering.apply(items, filter: .open, now: now, calendar: calendar)
+    #expect(result.count == 4)
+    #expect(result.contains(where: { $0.title == "No Due" }))
+    #expect(result.allSatisfy { !$0.isCompleted })
+  }
+
   @Test("Date filter")
   func dateFilter() {
     let now = Date(timeIntervalSince1970: 1_700_000_000)

--- a/docs/manual-tests.md
+++ b/docs/manual-tests.md
@@ -16,7 +16,7 @@ Run on a local GUI session (not SSH-only) so the Reminders permission prompt can
 - list lists: `remindctl list`
 - list list contents: `remindctl list "remindctl-manual-YYYYMMDD"`
 - add reminders (3 variants)
-- show filters: `today`, `tomorrow`, `week`, `overdue`, `upcoming`, `completed`, `all`
+- show filters: `today`, `tomorrow`, `week`, `overdue`, `upcoming`, `open`, `completed`, `all`
 - edit: update title/notes/priority/due date
 - complete: mark one reminder complete
 - delete: remove reminders, then delete list


### PR DESCRIPTION
## Summary

- Adds an `open` filter to the `show` command that returns all uncompleted reminders, regardless of whether they have a due date

## Motivation

The existing filters don't provide a way to see all incomplete reminders:
- `upcoming` only shows incomplete reminders **with due dates**
- `all` shows everything including completed items
- No filter catches undated incomplete items (e.g. grocery lists, open-ended tasks)

`remindctl open` fills this gap as the complement to `completed`.

## Usage

```bash
remindctl open                    # all incomplete reminders
remindctl show open --list Work   # incomplete in a specific list
remindctl open --json             # JSON output
```

## Changes

- `Sources/RemindCore/ReminderFilter.swift` — added `.open` enum case, parse token, and filter logic (`!isCompleted`)
- `Sources/remindctl/Commands/ShowCommand.swift` — updated help/discussion strings
- `Tests/RemindCoreTests/ReminderFilterParseTests.swift` — parse test for `"open"`
- `Tests/RemindCoreTests/ReminderFilteringTests.swift` — behavior test (includes no-due-date items, excludes completed)
- `README.md` — added usage example
- `docs/manual-tests.md` — updated filter checklist

## Test plan

- [x] `swift test --enable-code-coverage` — 23 tests passed
- [x] `make build` — release build succeeds
- [x] `remindctl show --help` — shows `open` in filter list
- [x] `remindctl open` — returns incomplete reminders (requires Reminders permission)

🤖 Generated with [Claude Code](https://claude.com/claude-code)