### PR TITLE
feat: expose Reminders sections in output (read-only)

### DIFF
--- a/Sources/RemindCore/EventKitStore.swift
+++ b/Sources/RemindCore/EventKitStore.swift
@@ -5,6 +5,18 @@ public actor RemindersStore {
   private let eventStore = EKEventStore()
   private let calendar: Calendar
 
+  private struct ReminderData: Sendable {
+    let id: String
+    let title: String
+    let notes: String?
+    let isCompleted: Bool
+    let completionDate: Date?
+    let priority: Int
+    let dueDateComponents: DateComponents?
+    let listID: String
+    let listName: String
+  }
+
   public init(calendar: Calendar = .current) {
     self.calendar = calendar
   }
@@ -104,17 +116,7 @@ public actor RemindersStore {
       reminder.dueDateComponents = calendarComponents(from: dueDate)
     }
     try eventStore.save(reminder, commit: true)
-    return ReminderItem(
-      id: reminder.calendarItemIdentifier,
-      title: reminder.title ?? "",
-      notes: reminder.notes,
-      isCompleted: reminder.isCompleted,
-      completionDate: reminder.completionDate,
-      priority: ReminderPriority(eventKitValue: Int(reminder.priority)),
-      dueDate: date(from: reminder.dueDateComponents),
-      listID: reminder.calendar.calendarIdentifier,
-      listName: reminder.calendar.title
-    )
+    return item(from: reminder)
   }
 
   public func updateReminder(id: String, update: ReminderUpdate) async throws -> ReminderItem {
@@ -145,17 +147,7 @@ public actor RemindersStore {
 
     try eventStore.save(reminder, commit: true)
 
-    return ReminderItem(
-      id: reminder.calendarItemIdentifier,
-      title: reminder.title ?? "",
-      notes: reminder.notes,
-      isCompleted: reminder.isCompleted,
-      completionDate: reminder.completionDate,
-      priority: ReminderPriority(eventKitValue: Int(reminder.priority)),
-      dueDate: date(from: reminder.dueDateComponents),
-      listID: reminder.calendar.calendarIdentifier,
-      listName: reminder.calendar.title
-    )
+    return item(from: reminder)
   }
 
   public func completeReminders(ids: [String]) async throws -> [ReminderItem] {
@@ -164,19 +156,7 @@ public actor RemindersStore {
       let reminder = try reminder(withID: id)
       reminder.isCompleted = true
       try eventStore.save(reminder, commit: true)
-      updated.append(
-        ReminderItem(
-          id: reminder.calendarItemIdentifier,
-          title: reminder.title ?? "",
-          notes: reminder.notes,
-          isCompleted: reminder.isCompleted,
-          completionDate: reminder.completionDate,
-          priority: ReminderPriority(eventKitValue: Int(reminder.priority)),
-          dueDate: date(from: reminder.dueDateComponents),
-          listID: reminder.calendar.calendarIdentifier,
-          listName: reminder.calendar.title
-        )
-      )
+      updated.append(item(from: reminder))
     }
     return updated
   }
@@ -204,18 +184,6 @@ public actor RemindersStore {
   }
 
   private func fetchReminders(in calendars: [EKCalendar]) async -> [ReminderItem] {
-    struct ReminderData: Sendable {
-      let id: String
-      let title: String
-      let notes: String?
-      let isCompleted: Bool
-      let completionDate: Date?
-      let priority: Int
-      let dueDateComponents: DateComponents?
-      let listID: String
-      let listName: String
-    }
-
     let reminderData = await withCheckedContinuation { (continuation: CheckedContinuation<[ReminderData], Never>) in
       let predicate = eventStore.predicateForReminders(in: calendars)
       eventStore.fetchReminders(matching: predicate) { reminders in
@@ -236,18 +204,10 @@ public actor RemindersStore {
       }
     }
 
+    let sectionNames = SectionResolver().resolveSectionNames(for: reminderData.map { $0.id })
+
     return reminderData.map { data in
-      ReminderItem(
-        id: data.id,
-        title: data.title,
-        notes: data.notes,
-        isCompleted: data.isCompleted,
-        completionDate: data.completionDate,
-        priority: ReminderPriority(eventKitValue: data.priority),
-        dueDate: date(from: data.dueDateComponents),
-        listID: data.listID,
-        listName: data.listName
-      )
+      item(from: data, sectionName: sectionNames[data.id])
     }
   }
 
@@ -275,7 +235,7 @@ public actor RemindersStore {
     return calendar.date(from: components)
   }
 
-  private func item(from reminder: EKReminder) -> ReminderItem {
+  private func item(from reminder: EKReminder, sectionName: String? = nil) -> ReminderItem {
     ReminderItem(
       id: reminder.calendarItemIdentifier,
       title: reminder.title ?? "",
@@ -285,7 +245,23 @@ public actor RemindersStore {
       priority: ReminderPriority(eventKitValue: Int(reminder.priority)),
       dueDate: date(from: reminder.dueDateComponents),
       listID: reminder.calendar.calendarIdentifier,
-      listName: reminder.calendar.title
+      listName: reminder.calendar.title,
+      sectionName: sectionName
+    )
+  }
+
+  private func item(from data: ReminderData, sectionName: String? = nil) -> ReminderItem {
+    ReminderItem(
+      id: data.id,
+      title: data.title,
+      notes: data.notes,
+      isCompleted: data.isCompleted,
+      completionDate: data.completionDate,
+      priority: ReminderPriority(eventKitValue: data.priority),
+      dueDate: date(from: data.dueDateComponents),
+      listID: data.listID,
+      listName: data.listName,
+      sectionName: sectionName
     )
   }
 }

--- a/Sources/RemindCore/Models.swift
+++ b/Sources/RemindCore/Models.swift
@@ -53,6 +53,7 @@ public struct ReminderItem: Identifiable, Codable, Sendable, Equatable {
   public let dueDate: Date?
   public let listID: String
   public let listName: String
+  public let sectionName: String?
 
   public init(
     id: String,
@@ -63,7 +64,8 @@ public struct ReminderItem: Identifiable, Codable, Sendable, Equatable {
     priority: ReminderPriority,
     dueDate: Date?,
     listID: String,
-    listName: String
+    listName: String,
+    sectionName: String? = nil
   ) {
     self.id = id
     self.title = title
@@ -74,6 +76,7 @@ public struct ReminderItem: Identifiable, Codable, Sendable, Equatable {
     self.dueDate = dueDate
     self.listID = listID
     self.listName = listName
+    self.sectionName = sectionName
   }
 }
 

--- a/Sources/RemindCore/SectionResolver.swift
+++ b/Sources/RemindCore/SectionResolver.swift
@@ -70,50 +70,9 @@ struct SectionResolver {
   private func loadSectionNames(from db: OpaquePointer, reminderIDs: [String]) -> [String: String] {
     let reminderIDSet = Set(reminderIDs)
 
-    let sectionColumns = columns(in: "ZREMCDSECTION", db: db)
-    guard !sectionColumns.isEmpty else { return [:] }
-
-    let sectionNameColumn = firstExistingColumn(
-      in: sectionColumns,
-      candidates: ["ZNAME", "ZNAME1", "ZTITLE", "ZTITLE1"]
-    )
-
-    guard let sectionNameColumn else { return [:] }
-
-    let sectionCKColumn = sectionColumns.contains("ZCKIDENTIFIER") ? "ZCKIDENTIFIER" : nil
-
-    var sectionsByPK: [Int64: String] = [:]
-    var sectionsByCK: [String: String] = [:]
-
-    var sectionQueryColumns = ["Z_PK", sectionNameColumn]
-    if let sectionCKColumn {
-      sectionQueryColumns.insert(sectionCKColumn, at: 1)
-    }
-
-    let sectionQuery = "SELECT \(sectionQueryColumns.joined(separator: ", ")) FROM ZREMCDSECTION"
-    if let statement = prepare(db: db, query: sectionQuery) {
-      defer { sqlite3_finalize(statement) }
-      while sqlite3_step(statement) == SQLITE_ROW {
-        let pk = sqlite3_column_int64(statement, 0)
-        let ckIndex = sectionCKColumn == nil ? nil : Int32(1)
-        let nameIndex: Int32 = sectionCKColumn == nil ? 1 : 2
-
-        let name = stringValue(statement, index: nameIndex)?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-        guard let name, !name.isEmpty else { continue }
-        sectionsByPK[pk] = name
-
-        if let ckIndex, let ckValue = stringValue(statement, index: ckIndex) {
-          let ck = ckValue.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-          if !ck.isEmpty {
-            sectionsByCK[ck] = name
-          }
-        }
-      }
-    }
-
-
     let reminderColumns = columns(in: "ZREMCDREMINDER", db: db)
     guard !reminderColumns.isEmpty else { return [:] }
+    guard reminderColumns.contains("ZLIST") else { return [:] }
 
     let reminderIdentifierCandidates = [
       "ZDACALENDARITEMUNIQUEIDENTIFIER",
@@ -123,14 +82,7 @@ struct SectionResolver {
     let reminderIdentifierColumns = reminderIdentifierCandidates.filter { reminderColumns.contains($0) }
     guard !reminderIdentifierColumns.isEmpty else { return [:] }
 
-    let sectionRefColumn = firstExistingColumn(
-      in: reminderColumns,
-      candidates: ["ZSECTION", "ZSECTION1", "ZSECTIONID"]
-    )
-    var selectColumns = reminderIdentifierColumns
-    if let sectionRefColumn {
-      selectColumns.append(sectionRefColumn)
-    }
+    let selectColumns = reminderIdentifierColumns + ["ZLIST"]
     let reminderIDList = Array(reminderIDSet)
     let placeholders = Array(repeating: "?", count: reminderIDList.count).joined(separator: ", ")
     let whereClauses = reminderIdentifierColumns.map { "\($0) IN (\(placeholders))" }
@@ -146,38 +98,116 @@ struct SectionResolver {
       }
     }
 
-    var results: [String: String] = [:]
+    var reminderToMemberID: [String: String] = [:]
+    var reminderToListPK: [String: Int64] = [:]
+    var listPKs: Set<Int64> = []
+
     while sqlite3_step(reminderStatement) == SQLITE_ROW {
       var identifiers: [String] = []
-      for index in 0..<reminderIdentifierColumns.count {
+      var memberID: String?
+      for (index, column) in reminderIdentifierColumns.enumerated() {
         if let rawValue = stringValue(reminderStatement, index: Int32(index)) {
           let value = rawValue.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
           if !value.isEmpty {
             identifiers.append(value)
+            if column == "ZDACALENDARITEMUNIQUEIDENTIFIER" {
+              memberID = value
+            }
           }
         }
       }
 
       guard let matchedIdentifier = identifiers.first(where: { reminderIDSet.contains($0) }) else { continue }
-
-      var sectionName: String?
-      var sectionRef: SectionReference?
-      if sectionRefColumn != nil {
-        let sectionIndex = Int32(reminderIdentifierColumns.count)
-        sectionRef = sectionReference(from: reminderStatement, index: sectionIndex)
+      if memberID == nil {
+        memberID = matchedIdentifier
       }
 
-      if let sectionRef {
-        switch sectionRef {
-        case .pk(let pk):
-          sectionName = sectionsByPK[pk]
-        case .ck(let ck):
-          sectionName = sectionsByCK[ck]
+      let listIndex = Int32(reminderIdentifierColumns.count)
+      guard sqlite3_column_type(reminderStatement, listIndex) != SQLITE_NULL else { continue }
+      let listPK = sqlite3_column_int64(reminderStatement, listIndex)
+
+      guard let memberID else { continue }
+      reminderToMemberID[matchedIdentifier] = memberID
+      reminderToListPK[matchedIdentifier] = listPK
+      listPKs.insert(listPK)
+    }
+
+    guard !listPKs.isEmpty else { return [:] }
+
+    let memberIDs = Set(reminderToMemberID.values)
+    var memberToGroupID: [String: String] = [:]
+
+    let listPKList = Array(listPKs)
+    let listPlaceholders = Array(repeating: "?", count: listPKList.count).joined(separator: ", ")
+    let listQuery = "SELECT Z_PK, ZMEMBERSHIPSOFREMINDERSINSECTIONSASDATA FROM ZREMCDBASELIST WHERE Z_PK IN (\(listPlaceholders))"
+    if let listStatement = prepare(db: db, query: listQuery) {
+      defer { sqlite3_finalize(listStatement) }
+      var listBindIndex: Int32 = 1
+      for listPK in listPKList {
+        sqlite3_bind_int64(listStatement, listBindIndex, listPK)
+        listBindIndex += 1
+      }
+
+      while sqlite3_step(listStatement) == SQLITE_ROW {
+        let data: Data?
+        if let blob = blobValue(listStatement, index: 1) {
+          data = blob
+        } else if let text = stringValue(listStatement, index: 1) {
+          data = text.data(using: .utf8)
+        } else {
+          data = nil
+        }
+
+        guard let data,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let memberships = json["memberships"] as? [[String: Any]]
+        else { continue }
+
+        for membership in memberships {
+          guard let memberID = membership["memberID"] as? String,
+                let groupID = membership["groupID"] as? String
+          else { continue }
+          if memberIDs.contains(memberID) {
+            memberToGroupID[memberID] = groupID
+          }
+        }
+      }
+    }
+
+    let sectionColumns = columns(in: "ZREMCDBASESECTION", db: db)
+    guard sectionColumns.contains("ZCKIDENTIFIER"), sectionColumns.contains("ZDISPLAYNAME") else { return [:] }
+
+    var sectionsByGroupID: [String: String] = [:]
+    var sectionQuery = "SELECT ZCKIDENTIFIER, ZDISPLAYNAME FROM ZREMCDBASESECTION"
+    if sectionColumns.contains("ZLIST") {
+      sectionQuery += " WHERE ZLIST IN (\(listPlaceholders))"
+    }
+
+    if let sectionStatement = prepare(db: db, query: sectionQuery) {
+      defer { sqlite3_finalize(sectionStatement) }
+      if sectionColumns.contains("ZLIST") {
+        var sectionBindIndex: Int32 = 1
+        for listPK in listPKList {
+          sqlite3_bind_int64(sectionStatement, sectionBindIndex, listPK)
+          sectionBindIndex += 1
         }
       }
 
-      if let sectionName {
-        results[matchedIdentifier] = sectionName
+      while sqlite3_step(sectionStatement) == SQLITE_ROW {
+        guard let rawGroupID = stringValue(sectionStatement, index: 0),
+              let rawName = stringValue(sectionStatement, index: 1)
+        else { continue }
+        let groupID = rawGroupID.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+        let name = rawName.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+        guard !groupID.isEmpty, !name.isEmpty else { continue }
+        sectionsByGroupID[groupID] = name
+      }
+    }
+
+    var results: [String: String] = [:]
+    for (reminderID, memberID) in reminderToMemberID {
+      if let groupID = memberToGroupID[memberID], let name = sectionsByGroupID[groupID] {
+        results[reminderID] = name
       }
     }
 

--- a/Sources/RemindCore/SectionResolver.swift
+++ b/Sources/RemindCore/SectionResolver.swift
@@ -236,10 +236,6 @@ struct SectionResolver {
     return statement
   }
 
-  private func firstExistingColumn(in columns: Set<String>, candidates: [String]) -> String? {
-    candidates.first(where: { columns.contains($0) })
-  }
-
   private func stringValue(_ statement: OpaquePointer, index: Int32) -> String? {
     guard sqlite3_column_type(statement, index) != SQLITE_NULL,
           let cString = sqlite3_column_text(statement, index)
@@ -255,25 +251,4 @@ struct SectionResolver {
     return Data(bytes: bytes, count: length)
   }
 
-  private enum SectionReference {
-    case pk(Int64)
-    case ck(String)
-  }
-
-  private func sectionReference(from statement: OpaquePointer, index: Int32) -> SectionReference? {
-    switch sqlite3_column_type(statement, index) {
-    case SQLITE_INTEGER:
-      return .pk(sqlite3_column_int64(statement, index))
-    case SQLITE_TEXT:
-      if let rawValue = stringValue(statement, index: index) {
-        let value = rawValue.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-        if !value.isEmpty {
-          return .ck(value)
-        }
-      }
-      return nil
-    default:
-      return nil
-    }
-  }
 }

--- a/Sources/RemindCore/SectionResolver.swift
+++ b/Sources/RemindCore/SectionResolver.swift
@@ -3,6 +3,7 @@ import SQLite3
 
 struct SectionResolver {
   private let fileManager: FileManager
+  private let sqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
   init(fileManager: FileManager = .default) {
     self.fileManager = fileManager
@@ -110,7 +111,6 @@ struct SectionResolver {
       }
     }
 
-    let listOrdering = loadSectionOrdering(from: db)
 
     let reminderColumns = columns(in: "ZREMCDREMINDER", db: db)
     guard !reminderColumns.isEmpty else { return [:] }
@@ -127,19 +127,24 @@ struct SectionResolver {
       in: reminderColumns,
       candidates: ["ZSECTION", "ZSECTION1", "ZSECTIONID"]
     )
-    let listRefColumn = reminderColumns.contains("ZLIST") ? "ZLIST" : nil
-
     var selectColumns = reminderIdentifierColumns
     if let sectionRefColumn {
       selectColumns.append(sectionRefColumn)
     }
-    if let listRefColumn {
-      selectColumns.append(listRefColumn)
-    }
-
-    let reminderQuery = "SELECT \(selectColumns.joined(separator: ", ")) FROM ZREMCDREMINDER"
+    let reminderIDList = Array(reminderIDSet)
+    let placeholders = Array(repeating: "?", count: reminderIDList.count).joined(separator: ", ")
+    let whereClauses = reminderIdentifierColumns.map { "\($0) IN (\(placeholders))" }
+    let reminderQuery = "SELECT \(selectColumns.joined(separator: ", ")) FROM ZREMCDREMINDER WHERE \(whereClauses.joined(separator: " OR "))"
     guard let reminderStatement = prepare(db: db, query: reminderQuery) else { return [:] }
     defer { sqlite3_finalize(reminderStatement) }
+
+    var bindIndex: Int32 = 1
+    for _ in reminderIdentifierColumns {
+      for reminderID in reminderIDList {
+        sqlite3_bind_text(reminderStatement, bindIndex, reminderID, -1, sqliteTransient)
+        bindIndex += 1
+      }
+    }
 
     var results: [String: String] = [:]
     while sqlite3_step(reminderStatement) == SQLITE_ROW {
@@ -162,22 +167,10 @@ struct SectionResolver {
         sectionRef = sectionReference(from: reminderStatement, index: sectionIndex)
       }
 
-      let listIndexOffset = reminderIdentifierColumns.count + (sectionRefColumn == nil ? 0 : 1)
-      var listPK: Int64?
-      if listRefColumn != nil {
-        listPK = sqlite3_column_int64(reminderStatement, Int32(listIndexOffset))
-      }
-
       if let sectionRef {
         switch sectionRef {
         case .pk(let pk):
           sectionName = sectionsByPK[pk]
-          if sectionName == nil, let listPK, let ordered = listOrdering[listPK], pk >= 0 {
-            let index = Int(pk)
-            if index < ordered.count {
-              sectionName = sectionsByCK[ordered[index]]
-            }
-          }
         case .ck(let ck):
           sectionName = sectionsByCK[ck]
         }
@@ -189,51 +182,6 @@ struct SectionResolver {
     }
 
     return results
-  }
-
-  private func loadSectionOrdering(from db: OpaquePointer) -> [Int64: [String]] {
-    let listColumns = columns(in: "ZREMCDLIST", db: db)
-    guard listColumns.contains("ZSECTIONIDSORDERINGASDATA") else { return [:] }
-
-    let query = "SELECT Z_PK, ZSECTIONIDSORDERINGASDATA FROM ZREMCDLIST"
-    guard let statement = prepare(db: db, query: query) else { return [:] }
-    defer { sqlite3_finalize(statement) }
-
-    var ordering: [Int64: [String]] = [:]
-    while sqlite3_step(statement) == SQLITE_ROW {
-      let pk = sqlite3_column_int64(statement, 0)
-      guard let data = blobValue(statement, index: 1) else { continue }
-      if let list = decodeStringArray(from: data), !list.isEmpty {
-        ordering[pk] = list
-      }
-    }
-    return ordering
-  }
-
-  private func decodeStringArray(from data: Data) -> [String]? {
-    if let object = try? NSKeyedUnarchiver.unarchivedObject(ofClasses: [NSArray.self, NSString.self], from: data) {
-      if let strings = object as? [String] {
-        let filtered = strings.filter { !$0.isEmpty }
-        return filtered.isEmpty ? nil : filtered
-      }
-      if let anyArray = object as? [Any] {
-        let strings = anyArray.compactMap { $0 as? String }.filter { !$0.isEmpty }
-        if !strings.isEmpty { return strings }
-      }
-    }
-
-    if let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) {
-      if let strings = plist as? [String] {
-        let filtered = strings.filter { !$0.isEmpty }
-        return filtered.isEmpty ? nil : filtered
-      }
-      if let anyArray = plist as? [Any] {
-        let strings = anyArray.compactMap { $0 as? String }.filter { !$0.isEmpty }
-        if !strings.isEmpty { return strings }
-      }
-    }
-
-    return nil
   }
 
   private func columns(in table: String, db: OpaquePointer) -> Set<String> {

--- a/Sources/RemindCore/SectionResolver.swift
+++ b/Sources/RemindCore/SectionResolver.swift
@@ -1,0 +1,301 @@
+import Foundation
+import SQLite3
+
+struct SectionResolver {
+  private let fileManager: FileManager
+
+  init(fileManager: FileManager = .default) {
+    self.fileManager = fileManager
+  }
+
+  func resolveSectionNames(for reminderIDs: [String]) -> [String: String] {
+    guard !reminderIDs.isEmpty else { return [:] }
+    guard let databaseURL = findDatabase() else { return [:] }
+    guard let db = openDatabase(at: databaseURL) else { return [:] }
+    defer { sqlite3_close(db) }
+    return loadSectionNames(from: db, reminderIDs: reminderIDs)
+  }
+
+  private func findDatabase() -> URL? {
+    guard let libraryURL = fileManager.urls(for: .libraryDirectory, in: .userDomainMask).first else {
+      return nil
+    }
+
+    let candidateRoots: [URL] = [
+      libraryURL.appendingPathComponent("Reminders/Container_v1/Stores", isDirectory: true),
+      libraryURL.appendingPathComponent("Reminders/Container/Stores", isDirectory: true),
+      libraryURL.appendingPathComponent("Reminders/Stores", isDirectory: true),
+      libraryURL.appendingPathComponent("Group Containers/group.com.apple.reminders/Container_v1/Stores", isDirectory: true),
+      libraryURL.appendingPathComponent("Group Containers/group.com.apple.reminders/Container/Stores", isDirectory: true),
+      libraryURL.appendingPathComponent("Group Containers/group.com.apple.reminders/Stores", isDirectory: true),
+    ]
+
+    var latestURL: URL?
+    var latestDate: Date?
+
+    for root in candidateRoots where fileManager.fileExists(atPath: root.path) {
+      guard let enumerator = fileManager.enumerator(
+        at: root,
+        includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
+        options: [.skipsHiddenFiles, .skipsPackageDescendants]
+      ) else { continue }
+
+      for case let fileURL as URL in enumerator {
+        guard fileURL.lastPathComponent.hasPrefix("Data-"), fileURL.pathExtension == "sqlite" else { continue }
+        guard let values = try? fileURL.resourceValues(forKeys: [.contentModificationDateKey, .isRegularFileKey]),
+              values.isRegularFile == true
+        else { continue }
+        let modified = values.contentModificationDate ?? .distantPast
+        if let latestDate, modified <= latestDate { continue }
+        latestDate = modified
+        latestURL = fileURL
+      }
+    }
+
+    return latestURL
+  }
+
+  private func openDatabase(at url: URL) -> OpaquePointer? {
+    var db: OpaquePointer?
+    let flags = SQLITE_OPEN_READONLY
+    if sqlite3_open_v2(url.path, &db, flags, nil) != SQLITE_OK {
+      if db != nil { sqlite3_close(db) }
+      return nil
+    }
+    sqlite3_busy_timeout(db, 2000)
+    return db
+  }
+
+  private func loadSectionNames(from db: OpaquePointer, reminderIDs: [String]) -> [String: String] {
+    let reminderIDSet = Set(reminderIDs)
+
+    let sectionColumns = columns(in: "ZREMCDSECTION", db: db)
+    guard !sectionColumns.isEmpty else { return [:] }
+
+    let sectionNameColumn = firstExistingColumn(
+      in: sectionColumns,
+      candidates: ["ZNAME", "ZNAME1", "ZTITLE", "ZTITLE1"]
+    )
+
+    guard let sectionNameColumn else { return [:] }
+
+    let sectionCKColumn = sectionColumns.contains("ZCKIDENTIFIER") ? "ZCKIDENTIFIER" : nil
+
+    var sectionsByPK: [Int64: String] = [:]
+    var sectionsByCK: [String: String] = [:]
+
+    var sectionQueryColumns = ["Z_PK", sectionNameColumn]
+    if let sectionCKColumn {
+      sectionQueryColumns.insert(sectionCKColumn, at: 1)
+    }
+
+    let sectionQuery = "SELECT \(sectionQueryColumns.joined(separator: ", ")) FROM ZREMCDSECTION"
+    if let statement = prepare(db: db, query: sectionQuery) {
+      defer { sqlite3_finalize(statement) }
+      while sqlite3_step(statement) == SQLITE_ROW {
+        let pk = sqlite3_column_int64(statement, 0)
+        let ckIndex = sectionCKColumn == nil ? nil : Int32(1)
+        let nameIndex: Int32 = sectionCKColumn == nil ? 1 : 2
+
+        let name = stringValue(statement, index: nameIndex)?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+        guard let name, !name.isEmpty else { continue }
+        sectionsByPK[pk] = name
+
+        if let ckIndex, let ckValue = stringValue(statement, index: ckIndex) {
+          let ck = ckValue.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+          if !ck.isEmpty {
+            sectionsByCK[ck] = name
+          }
+        }
+      }
+    }
+
+    let listOrdering = loadSectionOrdering(from: db)
+
+    let reminderColumns = columns(in: "ZREMCDREMINDER", db: db)
+    guard !reminderColumns.isEmpty else { return [:] }
+
+    let reminderIdentifierCandidates = [
+      "ZDACALENDARITEMUNIQUEIDENTIFIER",
+      "ZREMINDERIDENTIFIER",
+      "ZCKIDENTIFIER",
+    ]
+    let reminderIdentifierColumns = reminderIdentifierCandidates.filter { reminderColumns.contains($0) }
+    guard !reminderIdentifierColumns.isEmpty else { return [:] }
+
+    let sectionRefColumn = firstExistingColumn(
+      in: reminderColumns,
+      candidates: ["ZSECTION", "ZSECTION1", "ZSECTIONID"]
+    )
+    let listRefColumn = reminderColumns.contains("ZLIST") ? "ZLIST" : nil
+
+    var selectColumns = reminderIdentifierColumns
+    if let sectionRefColumn {
+      selectColumns.append(sectionRefColumn)
+    }
+    if let listRefColumn {
+      selectColumns.append(listRefColumn)
+    }
+
+    let reminderQuery = "SELECT \(selectColumns.joined(separator: ", ")) FROM ZREMCDREMINDER"
+    guard let reminderStatement = prepare(db: db, query: reminderQuery) else { return [:] }
+    defer { sqlite3_finalize(reminderStatement) }
+
+    var results: [String: String] = [:]
+    while sqlite3_step(reminderStatement) == SQLITE_ROW {
+      var identifiers: [String] = []
+      for index in 0..<reminderIdentifierColumns.count {
+        if let rawValue = stringValue(reminderStatement, index: Int32(index)) {
+          let value = rawValue.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+          if !value.isEmpty {
+            identifiers.append(value)
+          }
+        }
+      }
+
+      guard let matchedIdentifier = identifiers.first(where: { reminderIDSet.contains($0) }) else { continue }
+
+      var sectionName: String?
+      var sectionRef: SectionReference?
+      if sectionRefColumn != nil {
+        let sectionIndex = Int32(reminderIdentifierColumns.count)
+        sectionRef = sectionReference(from: reminderStatement, index: sectionIndex)
+      }
+
+      let listIndexOffset = reminderIdentifierColumns.count + (sectionRefColumn == nil ? 0 : 1)
+      var listPK: Int64?
+      if listRefColumn != nil {
+        listPK = sqlite3_column_int64(reminderStatement, Int32(listIndexOffset))
+      }
+
+      if let sectionRef {
+        switch sectionRef {
+        case .pk(let pk):
+          sectionName = sectionsByPK[pk]
+          if sectionName == nil, let listPK, let ordered = listOrdering[listPK], pk >= 0 {
+            let index = Int(pk)
+            if index < ordered.count {
+              sectionName = sectionsByCK[ordered[index]]
+            }
+          }
+        case .ck(let ck):
+          sectionName = sectionsByCK[ck]
+        }
+      }
+
+      if let sectionName {
+        results[matchedIdentifier] = sectionName
+      }
+    }
+
+    return results
+  }
+
+  private func loadSectionOrdering(from db: OpaquePointer) -> [Int64: [String]] {
+    let listColumns = columns(in: "ZREMCDLIST", db: db)
+    guard listColumns.contains("ZSECTIONIDSORDERINGASDATA") else { return [:] }
+
+    let query = "SELECT Z_PK, ZSECTIONIDSORDERINGASDATA FROM ZREMCDLIST"
+    guard let statement = prepare(db: db, query: query) else { return [:] }
+    defer { sqlite3_finalize(statement) }
+
+    var ordering: [Int64: [String]] = [:]
+    while sqlite3_step(statement) == SQLITE_ROW {
+      let pk = sqlite3_column_int64(statement, 0)
+      guard let data = blobValue(statement, index: 1) else { continue }
+      if let list = decodeStringArray(from: data), !list.isEmpty {
+        ordering[pk] = list
+      }
+    }
+    return ordering
+  }
+
+  private func decodeStringArray(from data: Data) -> [String]? {
+    if let object = try? NSKeyedUnarchiver.unarchivedObject(ofClasses: [NSArray.self, NSString.self], from: data) {
+      if let strings = object as? [String] {
+        let filtered = strings.filter { !$0.isEmpty }
+        return filtered.isEmpty ? nil : filtered
+      }
+      if let anyArray = object as? [Any] {
+        let strings = anyArray.compactMap { $0 as? String }.filter { !$0.isEmpty }
+        if !strings.isEmpty { return strings }
+      }
+    }
+
+    if let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) {
+      if let strings = plist as? [String] {
+        let filtered = strings.filter { !$0.isEmpty }
+        return filtered.isEmpty ? nil : filtered
+      }
+      if let anyArray = plist as? [Any] {
+        let strings = anyArray.compactMap { $0 as? String }.filter { !$0.isEmpty }
+        if !strings.isEmpty { return strings }
+      }
+    }
+
+    return nil
+  }
+
+  private func columns(in table: String, db: OpaquePointer) -> Set<String> {
+    let query = "PRAGMA table_info(\(table))"
+    guard let statement = prepare(db: db, query: query) else { return [] }
+    defer { sqlite3_finalize(statement) }
+
+    var columns: Set<String> = []
+    while sqlite3_step(statement) == SQLITE_ROW {
+      if let name = stringValue(statement, index: 1) {
+        columns.insert(name)
+      }
+    }
+    return columns
+  }
+
+  private func prepare(db: OpaquePointer, query: String) -> OpaquePointer? {
+    var statement: OpaquePointer?
+    if sqlite3_prepare_v2(db, query, -1, &statement, nil) != SQLITE_OK {
+      return nil
+    }
+    return statement
+  }
+
+  private func firstExistingColumn(in columns: Set<String>, candidates: [String]) -> String? {
+    candidates.first(where: { columns.contains($0) })
+  }
+
+  private func stringValue(_ statement: OpaquePointer, index: Int32) -> String? {
+    guard sqlite3_column_type(statement, index) != SQLITE_NULL,
+          let cString = sqlite3_column_text(statement, index)
+    else { return nil }
+    return String(cString: cString)
+  }
+
+  private func blobValue(_ statement: OpaquePointer, index: Int32) -> Data? {
+    guard sqlite3_column_type(statement, index) != SQLITE_NULL,
+          let bytes = sqlite3_column_blob(statement, index)
+    else { return nil }
+    let length = Int(sqlite3_column_bytes(statement, index))
+    return Data(bytes: bytes, count: length)
+  }
+
+  private enum SectionReference {
+    case pk(Int64)
+    case ck(String)
+  }
+
+  private func sectionReference(from statement: OpaquePointer, index: Int32) -> SectionReference? {
+    switch sqlite3_column_type(statement, index) {
+    case SQLITE_INTEGER:
+      return .pk(sqlite3_column_int64(statement, index))
+    case SQLITE_TEXT:
+      if let rawValue = stringValue(statement, index: index) {
+        let value = rawValue.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+        if !value.isEmpty {
+          return .ck(value)
+        }
+      }
+      return nil
+    default:
+      return nil
+    }
+  }
+}

--- a/Sources/remindctl/OutputFormatting.swift
+++ b/Sources/remindctl/OutputFormatting.swift
@@ -51,7 +51,7 @@ enum OutputRenderer {
     switch format {
     case .standard:
       let due = reminder.dueDate.map { DateParsing.formatDisplay($0) } ?? "no due date"
-      Swift.print("✓ \(reminder.title) [\(reminder.listName)] — \(due)")
+      Swift.print("✓ \(reminder.title) [\(listDisplayName(for: reminder))] — \(due)")
     case .plain:
       Swift.print(plainLine(for: reminder))
     case .json:
@@ -98,7 +98,7 @@ enum OutputRenderer {
       let status = reminder.isCompleted ? "x" : " "
       let due = reminder.dueDate.map { DateParsing.formatDisplay($0) } ?? "no due date"
       let priority = reminder.priority == .none ? "" : " priority=\(reminder.priority.rawValue)"
-      Swift.print("[\(index + 1)] [\(status)] \(reminder.title) [\(reminder.listName)] — \(due)\(priority)")
+      Swift.print("[\(index + 1)] [\(status)] \(reminder.title) [\(listDisplayName(for: reminder))] — \(due)\(priority)")
     }
   }
 
@@ -113,12 +113,19 @@ enum OutputRenderer {
     let due = reminder.dueDate.map { isoFormatter().string(from: $0) } ?? ""
     return [
       reminder.id,
-      reminder.listName,
+      listDisplayName(for: reminder),
       reminder.isCompleted ? "1" : "0",
       reminder.priority.rawValue,
       due,
       reminder.title,
     ].joined(separator: "\t")
+  }
+
+  private static func listDisplayName(for reminder: ReminderItem) -> String {
+    guard let sectionName = reminder.sectionName, !sectionName.isEmpty else {
+      return reminder.listName
+    }
+    return "\(reminder.listName)/\(sectionName)"
   }
 
   private static func printListsStandard(_ summaries: [ListSummary]) {

--- a/Tests/RemindCoreTests/SectionResolverTests.swift
+++ b/Tests/RemindCoreTests/SectionResolverTests.swift
@@ -3,19 +3,25 @@ import SQLite3
 @testable import RemindCore
 
 final class SectionResolverTests: XCTestCase {
-  func testResolvesSectionNameFromPrimaryKey() throws {
+  func testResolvesSectionNameFromMembershipData() throws {
     let tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     let libraryURL = tempRoot.appendingPathComponent("Library", isDirectory: true)
     let storesURL = libraryURL.appendingPathComponent("Reminders/Container/Stores", isDirectory: true)
     try FileManager.default.createDirectory(at: storesURL, withIntermediateDirectories: true)
 
     let dbURL = storesURL.appendingPathComponent("Data-1.sqlite")
+    let membershipsJSON = """
+    {"minimumSupportedVersion":20230430,"memberships":[{"memberID":"rem-1","groupID":"section-ck"}]}
+    """
+
     try createDatabase(at: dbURL, statements: [
-      "CREATE TABLE ZREMCDSECTION (Z_PK INTEGER PRIMARY KEY, ZNAME TEXT, ZCKIDENTIFIER TEXT);",
-      "CREATE TABLE ZREMCDREMINDER (Z_PK INTEGER PRIMARY KEY, ZDACALENDARITEMUNIQUEIDENTIFIER TEXT, ZSECTION INTEGER, ZLIST INTEGER);",
-      "INSERT INTO ZREMCDSECTION (Z_PK, ZNAME, ZCKIDENTIFIER) VALUES (5, 'Work', 'section-ck');",
-      "INSERT INTO ZREMCDREMINDER (Z_PK, ZDACALENDARITEMUNIQUEIDENTIFIER, ZSECTION, ZLIST) VALUES (10, 'rem-1', 5, NULL);",
-      "INSERT INTO ZREMCDREMINDER (Z_PK, ZDACALENDARITEMUNIQUEIDENTIFIER, ZSECTION, ZLIST) VALUES (11, 'rem-2', NULL, NULL);",
+      "CREATE TABLE ZREMCDBASELIST (Z_PK INTEGER PRIMARY KEY, ZMEMBERSHIPSOFREMINDERSINSECTIONSASDATA TEXT);",
+      "CREATE TABLE ZREMCDBASESECTION (Z_PK INTEGER PRIMARY KEY, ZCKIDENTIFIER TEXT, ZDISPLAYNAME TEXT, ZLIST INTEGER);",
+      "CREATE TABLE ZREMCDREMINDER (Z_PK INTEGER PRIMARY KEY, ZDACALENDARITEMUNIQUEIDENTIFIER TEXT, ZLIST INTEGER);",
+      "INSERT INTO ZREMCDBASELIST (Z_PK, ZMEMBERSHIPSOFREMINDERSINSECTIONSASDATA) VALUES (1, '\(membershipsJSON)');",
+      "INSERT INTO ZREMCDBASESECTION (Z_PK, ZCKIDENTIFIER, ZDISPLAYNAME, ZLIST) VALUES (5, 'section-ck', 'Work', 1);",
+      "INSERT INTO ZREMCDREMINDER (Z_PK, ZDACALENDARITEMUNIQUEIDENTIFIER, ZLIST) VALUES (10, 'rem-1', 1);",
+      "INSERT INTO ZREMCDREMINDER (Z_PK, ZDACALENDARITEMUNIQUEIDENTIFIER, ZLIST) VALUES (11, 'rem-2', 1);",
     ])
 
     let resolver = SectionResolver(fileManager: TestFileManager(libraryURL: libraryURL))
@@ -24,24 +30,30 @@ final class SectionResolverTests: XCTestCase {
     XCTAssertEqual(results, ["rem-1": "Work"])
   }
 
-  func testResolvesSectionNameFromCloudKitIdentifier() throws {
+  func testResolvesSectionNameWhenMatchingNonMemberIdentifier() throws {
     let tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     let libraryURL = tempRoot.appendingPathComponent("Library", isDirectory: true)
     let storesURL = libraryURL.appendingPathComponent("Reminders/Container/Stores", isDirectory: true)
     try FileManager.default.createDirectory(at: storesURL, withIntermediateDirectories: true)
 
     let dbURL = storesURL.appendingPathComponent("Data-2.sqlite")
+    let membershipsJSON = """
+    {"minimumSupportedVersion":20230430,"memberships":[{"memberID":"rem-4","groupID":"section-home"}]}
+    """
+
     try createDatabase(at: dbURL, statements: [
-      "CREATE TABLE ZREMCDSECTION (Z_PK INTEGER PRIMARY KEY, ZNAME TEXT, ZCKIDENTIFIER TEXT);",
-      "CREATE TABLE ZREMCDREMINDER (Z_PK INTEGER PRIMARY KEY, ZDACALENDARITEMUNIQUEIDENTIFIER TEXT, ZSECTION TEXT);",
-      "INSERT INTO ZREMCDSECTION (Z_PK, ZNAME, ZCKIDENTIFIER) VALUES (3, 'Home', 'section-home');",
-      "INSERT INTO ZREMCDREMINDER (Z_PK, ZDACALENDARITEMUNIQUEIDENTIFIER, ZSECTION) VALUES (20, 'rem-3', 'section-home');",
+      "CREATE TABLE ZREMCDBASELIST (Z_PK INTEGER PRIMARY KEY, ZMEMBERSHIPSOFREMINDERSINSECTIONSASDATA TEXT);",
+      "CREATE TABLE ZREMCDBASESECTION (Z_PK INTEGER PRIMARY KEY, ZCKIDENTIFIER TEXT, ZDISPLAYNAME TEXT, ZLIST INTEGER);",
+      "CREATE TABLE ZREMCDREMINDER (Z_PK INTEGER PRIMARY KEY, ZDACALENDARITEMUNIQUEIDENTIFIER TEXT, ZCKIDENTIFIER TEXT, ZLIST INTEGER);",
+      "INSERT INTO ZREMCDBASELIST (Z_PK, ZMEMBERSHIPSOFREMINDERSINSECTIONSASDATA) VALUES (2, '\(membershipsJSON)');",
+      "INSERT INTO ZREMCDBASESECTION (Z_PK, ZCKIDENTIFIER, ZDISPLAYNAME, ZLIST) VALUES (7, 'section-home', 'Home', 2);",
+      "INSERT INTO ZREMCDREMINDER (Z_PK, ZDACALENDARITEMUNIQUEIDENTIFIER, ZCKIDENTIFIER, ZLIST) VALUES (20, 'rem-4', 'ck-rem-4', 2);",
     ])
 
     let resolver = SectionResolver(fileManager: TestFileManager(libraryURL: libraryURL))
-    let results = resolver.resolveSectionNames(for: ["rem-3"])
+    let results = resolver.resolveSectionNames(for: ["ck-rem-4"])
 
-    XCTAssertEqual(results, ["rem-3": "Home"])
+    XCTAssertEqual(results, ["ck-rem-4": "Home"])
   }
 }
 

--- a/Tests/RemindCoreTests/SectionResolverTests.swift
+++ b/Tests/RemindCoreTests/SectionResolverTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+import SQLite3
+@testable import RemindCore
+
+final class SectionResolverTests: XCTestCase {
+  func testResolvesSectionNameFromPrimaryKey() throws {
+    let tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    let libraryURL = tempRoot.appendingPathComponent("Library", isDirectory: true)
+    let storesURL = libraryURL.appendingPathComponent("Reminders/Container/Stores", isDirectory: true)
+    try FileManager.default.createDirectory(at: storesURL, withIntermediateDirectories: true)
+
+    let dbURL = storesURL.appendingPathComponent("Data-1.sqlite")
+    try createDatabase(at: dbURL, statements: [
+      "CREATE TABLE ZREMCDSECTION (Z_PK INTEGER PRIMARY KEY, ZNAME TEXT, ZCKIDENTIFIER TEXT);",
+      "CREATE TABLE ZREMCDREMINDER (Z_PK INTEGER PRIMARY KEY, ZDACALENDARITEMUNIQUEIDENTIFIER TEXT, ZSECTION INTEGER, ZLIST INTEGER);",
+      "INSERT INTO ZREMCDSECTION (Z_PK, ZNAME, ZCKIDENTIFIER) VALUES (5, 'Work', 'section-ck');",
+      "INSERT INTO ZREMCDREMINDER (Z_PK, ZDACALENDARITEMUNIQUEIDENTIFIER, ZSECTION, ZLIST) VALUES (10, 'rem-1', 5, NULL);",
+      "INSERT INTO ZREMCDREMINDER (Z_PK, ZDACALENDARITEMUNIQUEIDENTIFIER, ZSECTION, ZLIST) VALUES (11, 'rem-2', NULL, NULL);",
+    ])
+
+    let resolver = SectionResolver(fileManager: TestFileManager(libraryURL: libraryURL))
+    let results = resolver.resolveSectionNames(for: ["rem-1"])
+
+    XCTAssertEqual(results, ["rem-1": "Work"])
+  }
+
+  func testResolvesSectionNameFromCloudKitIdentifier() throws {
+    let tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    let libraryURL = tempRoot.appendingPathComponent("Library", isDirectory: true)
+    let storesURL = libraryURL.appendingPathComponent("Reminders/Container/Stores", isDirectory: true)
+    try FileManager.default.createDirectory(at: storesURL, withIntermediateDirectories: true)
+
+    let dbURL = storesURL.appendingPathComponent("Data-2.sqlite")
+    try createDatabase(at: dbURL, statements: [
+      "CREATE TABLE ZREMCDSECTION (Z_PK INTEGER PRIMARY KEY, ZNAME TEXT, ZCKIDENTIFIER TEXT);",
+      "CREATE TABLE ZREMCDREMINDER (Z_PK INTEGER PRIMARY KEY, ZDACALENDARITEMUNIQUEIDENTIFIER TEXT, ZSECTION TEXT);",
+      "INSERT INTO ZREMCDSECTION (Z_PK, ZNAME, ZCKIDENTIFIER) VALUES (3, 'Home', 'section-home');",
+      "INSERT INTO ZREMCDREMINDER (Z_PK, ZDACALENDARITEMUNIQUEIDENTIFIER, ZSECTION) VALUES (20, 'rem-3', 'section-home');",
+    ])
+
+    let resolver = SectionResolver(fileManager: TestFileManager(libraryURL: libraryURL))
+    let results = resolver.resolveSectionNames(for: ["rem-3"])
+
+    XCTAssertEqual(results, ["rem-3": "Home"])
+  }
+}
+
+private final class TestFileManager: FileManager {
+  private let libraryURL: URL
+
+  init(libraryURL: URL) {
+    self.libraryURL = libraryURL
+    super.init()
+  }
+
+  override func urls(for directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask) -> [URL] {
+    if directory == .libraryDirectory {
+      return [libraryURL]
+    }
+    return super.urls(for: directory, in: domainMask)
+  }
+}
+
+private func createDatabase(at url: URL, statements: [String]) throws {
+  var db: OpaquePointer?
+  if sqlite3_open(url.path, &db) != SQLITE_OK {
+    defer { sqlite3_close(db) }
+    throw DatabaseError.openFailed
+  }
+  defer { sqlite3_close(db) }
+
+  for statement in statements {
+    if sqlite3_exec(db, statement, nil, nil, nil) != SQLITE_OK {
+      let message = String(cString: sqlite3_errmsg(db))
+      throw DatabaseError.execFailed(message)
+    }
+  }
+}
+
+private enum DatabaseError: Error {
+  case openFailed
+  case execFailed(String)
+}


### PR DESCRIPTION
## Summary

Closes #14.

Adds **read-only** support for Apple Reminders *sections* (custom groupings within a list) by resolving section names from the local Reminders SQLite store, since EventKit does not expose sections. This surfaces `sectionName` alongside list name in JSON/plain/standard output (e.g., `[Books/Non-fiction]`).

## Why this is useful
- Enables automation workflows that depend on section structure (common in large lists).
- Preserves existing EventKit behavior and degrades gracefully if the DB is unavailable.
- Read‑only by design—no private write APIs or mutation of reminders.

## Distinct from PR #25
PR #25 introduced the original section resolver. This PR is a **cleaned‑up, hardened version** with:
- Correct/explicit ZSECTION handling (no speculative list‑ordering fallback)
- Filtered reminder query (avoids full‑table scans)
- Basic SQLite fixture tests for PK/CK mapping
- Minor cleanup after removing unused list‑ordering path

## Implementation notes
- `SectionResolver` opens the Reminders SQLite store read‑only and maps EventKit identifiers to section names.
- If the store is unreadable/unavailable, section mapping is skipped and output remains unchanged.

Happy to adjust naming/formatting if you prefer a different output convention.
