### PR TITLE
docs: integrate Homebrew tap update into local release flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Add a release helper for Homebrew tap updates; thanks @dinakars777.
+
 ## 0.2.0 - 2026-05-04
 - Add location-based reminder triggers via `--location`, `--leaving`, and `--radius`
 - Add simple recurrence support via `--repeat` and `--no-repeat`

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -31,7 +31,7 @@
      gh release create v0.2.0 /tmp/remindctl-macos.zip -t "v0.2.0" -F /tmp/release-notes.txt
      ```
 5. Update Homebrew tap
-   - Run `scripts/update-homebrew.sh vX.Y.Z` to trigger the centralized formula updater.
+   - Run `scripts/update-homebrew.sh vX.Y.Z` to trigger and watch the centralized formula updater.
    - Requires a GitHub token with workflow dispatch access to `steipete/homebrew-tap`.
 
 ## What happens in CI

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -30,8 +30,9 @@
      ```sh
      gh release create v0.2.0 /tmp/remindctl-macos.zip -t "v0.2.0" -F /tmp/release-notes.txt
      ```
-5. Homebrew tap
-   - Update `../homebrew-tap/Formula/remindctl.rb` to point at the GitHub release asset.
+5. Update Homebrew tap
+   - Run `scripts/update-homebrew.sh vX.Y.Z` to trigger the centralized formula updater.
+   - Requires a GitHub token with workflow dispatch access to `steipete/homebrew-tap`.
 
 ## What happens in CI
 - Release signing + notarization are done locally via `scripts/sign-and-notarize.sh`.

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -7,13 +7,44 @@ if [[ $# -ne 1 ]]; then
 fi
 
 TAG="$1"
+TAP_REPO="steipete/homebrew-tap"
+WORKFLOW="update-formula.yml"
+SAFE_TAG=$(printf '%s' "$TAG" | tr -c 'A-Za-z0-9._-' '-')
+REQUEST_ID="remindctl-${SAFE_TAG}-$(date -u +%Y%m%dT%H%M%SZ)-$$"
 
-gh workflow run update-formula.yml \
-  --repo steipete/homebrew-tap \
+gh workflow run "$WORKFLOW" \
+  --repo "$TAP_REPO" \
   --ref main \
   -f formula=remindctl \
   -f tag="$TAG" \
   -f repository=steipete/remindctl \
-  -f macos_artifact="remindctl-macos.zip"
+  -f macos_artifact="remindctl-macos.zip" \
+  -f request_id="$REQUEST_ID"
 
-echo "Homebrew tap update dispatched. Monitor: https://github.com/steipete/homebrew-tap/actions"
+echo "Homebrew tap update dispatched: $REQUEST_ID"
+
+RUN_ID=""
+for _ in {1..30}; do
+  RUN_ID=$(gh run list \
+    --repo "$TAP_REPO" \
+    --workflow "$WORKFLOW" \
+    --branch main \
+    --limit 20 \
+    --json databaseId,displayTitle \
+    --jq ".[] | select(.displayTitle | contains(\"($REQUEST_ID)\")) | .databaseId" \
+    | head -n 1)
+
+  if [[ -n "$RUN_ID" ]]; then
+    break
+  fi
+
+  sleep 2
+done
+
+if [[ -z "$RUN_ID" ]]; then
+  echo "Timed out waiting for Homebrew tap workflow run: $REQUEST_ID" >&2
+  echo "Monitor: https://github.com/$TAP_REPO/actions/workflows/$WORKFLOW" >&2
+  exit 1
+fi
+
+gh run watch "$RUN_ID" --repo "$TAP_REPO" --exit-status

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <release-tag>" >&2
+  exit 1
+fi
+
+TAG="$1"
+
+gh workflow run update-formula.yml \
+  --repo steipete/homebrew-tap \
+  --ref main \
+  -f formula=remindctl \
+  -f tag="$TAG" \
+  -f repository=steipete/remindctl \
+  -f macos_artifact="remindctl-macos.zip"
+
+echo "Homebrew tap update dispatched. Monitor: https://github.com/steipete/homebrew-tap/actions"


### PR DESCRIPTION
Follow-up to #49 (closed). Instead of wiring the tap update into the CI workflow (which isn't the primary release path), this adds a lightweight `scripts/update-homebrew.sh` helper that integrates with the existing local signing + notarization release flow.

### What changed
- **`scripts/update-homebrew.sh`** — dispatches the centralized formula updater in `steipete/homebrew-tap` via `gh workflow run`
- **`docs/RELEASING.md`** — replaces the old manual "update the .rb file" step with `scripts/update-homebrew.sh vX.Y.Z`

### Why this approach
We considered moving the entire release flow into CI (so the tap update could fire automatically), but that would require uploading your Apple Developer signing certificate and App Store Connect API keys as GitHub secrets — a significant security/trust decision that should be driven by you, not a contributor PR. This approach keeps the local signing flow untouched and just automates the last mile (Homebrew formula update) with a one-liner.

### Requires
- `steipete/homebrew-tap#29` merged ✅
- A GitHub token with `workflow` scope (for `gh workflow run` against the tap)