### PR TITLE
fix: align numeric index resolution with show output

### DIFF
--- a/Sources/RemindCore/Errors.swift
+++ b/Sources/RemindCore/Errors.swift
@@ -7,6 +7,7 @@ public enum RemindCoreError: LocalizedError, Sendable, Equatable {
   case reminderNotFound(String)
   case ambiguousIdentifier(String, matches: [String])
   case invalidIdentifier(String)
+  case numericIndexWithoutContext(Int)
   case invalidDate(String)
   case unsupported(String)
   case operationFailed(String)
@@ -35,6 +36,11 @@ public enum RemindCoreError: LocalizedError, Sendable, Equatable {
       return "Identifier \"\(input)\" matches multiple reminders: \(matches.joined(separator: ", "))."
     case .invalidIdentifier(let input):
       return "Invalid identifier: \"\(input)\"."
+    case .numericIndexWithoutContext(let index):
+      return [
+        "No recent `remindctl show` output to resolve index \(index).",
+        "Run `remindctl show` first, or pass an ID prefix.",
+      ].joined(separator: " ")
     case .invalidDate(let input):
       return "Invalid date: \"\(input)\"."
     case .unsupported(let message):

--- a/Sources/RemindCore/IDResolver.swift
+++ b/Sources/RemindCore/IDResolver.swift
@@ -14,9 +14,7 @@ public enum IDResolver {
       let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
       if let index = Int(trimmed) {
         guard let indexedIDs else {
-          throw RemindCoreError.operationFailed(
-            "No recent `remindctl show` output to resolve index \(index). Run `remindctl show` first, or pass an ID prefix."
-          )
+          throw RemindCoreError.numericIndexWithoutContext(index)
         }
         let idx = index - 1
         guard idx >= 0 && idx < indexedIDs.count else {

--- a/Sources/RemindCore/IDResolver.swift
+++ b/Sources/RemindCore/IDResolver.swift
@@ -5,18 +5,28 @@ public enum IDResolver {
 
   public static func resolve(
     _ inputs: [String],
-    from reminders: [ReminderItem]
+    from reminders: [ReminderItem],
+    indexedIDs: [String]? = nil
   ) throws -> [ReminderItem] {
     let sorted = ReminderFiltering.sort(reminders)
     var resolved: [ReminderItem] = []
     for input in inputs {
       let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
       if let index = Int(trimmed) {
+        guard let indexedIDs else {
+          throw RemindCoreError.operationFailed(
+            "No recent `remindctl show` output to resolve index \(index). Run `remindctl show` first, or pass an ID prefix."
+          )
+        }
         let idx = index - 1
-        guard idx >= 0 && idx < sorted.count else {
+        guard idx >= 0 && idx < indexedIDs.count else {
           throw RemindCoreError.invalidIdentifier(trimmed)
         }
-        resolved.append(sorted[idx])
+        let id = indexedIDs[idx]
+        guard let match = sorted.first(where: { $0.id == id }) else {
+          throw RemindCoreError.reminderNotFound(id)
+        }
+        resolved.append(match)
         continue
       }
 

--- a/Sources/remindctl/Commands/CompleteCommand.swift
+++ b/Sources/remindctl/Commands/CompleteCommand.swift
@@ -32,7 +32,7 @@ enum CompleteCommand {
       let store = RemindersStore()
       try await store.requestAccess()
       let reminders = try await store.reminders(in: nil)
-      let resolved = try IDResolver.resolve(inputs, from: reminders)
+      let resolved = try IDResolver.resolve(inputs, from: reminders, indexedIDs: IndexCache.load())
 
       if values.flag("dryRun") {
         OutputRenderer.printReminders(resolved, format: runtime.outputFormat)

--- a/Sources/remindctl/Commands/DeleteCommand.swift
+++ b/Sources/remindctl/Commands/DeleteCommand.swift
@@ -33,7 +33,7 @@ enum DeleteCommand {
       let store = RemindersStore()
       try await store.requestAccess()
       let reminders = try await store.reminders(in: nil)
-      let resolved = try IDResolver.resolve(inputs, from: reminders)
+      let resolved = try IDResolver.resolve(inputs, from: reminders, indexedIDs: IndexCache.load())
 
       if values.flag("dryRun") {
         OutputRenderer.printReminders(resolved, format: runtime.outputFormat)

--- a/Sources/remindctl/Commands/EditCommand.swift
+++ b/Sources/remindctl/Commands/EditCommand.swift
@@ -57,7 +57,7 @@ enum EditCommand {
       let store = RemindersStore()
       try await store.requestAccess()
       let reminders = try await store.reminders(in: nil)
-      let resolved = try IDResolver.resolve([input], from: reminders)
+      let resolved = try IDResolver.resolve([input], from: reminders, indexedIDs: IndexCache.load())
       guard let reminder = resolved.first else {
         throw RemindCoreError.reminderNotFound(input)
       }

--- a/Sources/remindctl/Commands/ListCommand.swift
+++ b/Sources/remindctl/Commands/ListCommand.swift
@@ -86,6 +86,7 @@ enum ListCommand {
         }
 
         let reminders = try await reminders(in: names, store: store)
+        try? IndexCache.save(ReminderFiltering.sort(reminders).map { $0.id })
         OutputRenderer.printReminders(reminders, format: runtime.outputFormat)
         return
       }

--- a/Sources/remindctl/Commands/ShowCommand.swift
+++ b/Sources/remindctl/Commands/ShowCommand.swift
@@ -52,6 +52,7 @@ enum ShowCommand {
       try await store.requestAccess()
       let reminders = try await store.reminders(in: listName)
       let filtered = ReminderFiltering.apply(reminders, filter: filter)
+      try? IndexCache.save(ReminderFiltering.sort(filtered).map { $0.id })
       OutputRenderer.printReminders(filtered, format: runtime.outputFormat)
     }
   }

--- a/Sources/remindctl/IndexCache.swift
+++ b/Sources/remindctl/IndexCache.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+enum IndexCache {
+  private struct Payload: Codable {
+    let savedAt: Date
+    let reminderIDs: [String]
+  }
+
+  static var path: URL {
+    let cachesDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+      ?? URL(fileURLWithPath: NSTemporaryDirectory())
+    return cachesDir.appending(path: "remindctl/index.json")
+  }
+
+  static func save(_ ids: [String]) throws {
+    let url = path
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let data = try encoder.encode(Payload(savedAt: Date(), reminderIDs: ids))
+    try data.write(to: url, options: .atomic)
+  }
+
+  static func load() -> [String]? {
+    guard let data = try? Data(contentsOf: path) else { return nil }
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return (try? decoder.decode(Payload.self, from: data))?.reminderIDs
+  }
+}

--- a/Tests/RemindCoreTests/IDResolverTests.swift
+++ b/Tests/RemindCoreTests/IDResolverTests.swift
@@ -32,13 +32,46 @@ struct IDResolverTests {
     ]
   }
 
-  @Test("Resolve by index")
+  @Test("Resolve by index uses indexedIDs")
   func resolveIndex() throws {
-    let resolved = try IDResolver.resolve(["1"], from: sampleReminders())
-    #expect(resolved.first?.title == "First")
+    let resolved = try IDResolver.resolve(
+      ["2"],
+      from: sampleReminders(),
+      indexedIDs: ["abcd1234", "abce5678"]
+    )
+    #expect(resolved.first?.title == "Second")
   }
 
-  @Test("Resolve by prefix")
+  @Test("Numeric input without indexedIDs throws")
+  func numericWithoutIndexedIDsThrows() {
+    #expect(throws: Error.self) {
+      _ = try IDResolver.resolve(["1"], from: sampleReminders())
+    }
+  }
+
+  @Test("Numeric out of range throws")
+  func numericOutOfRangeThrows() {
+    #expect(throws: Error.self) {
+      _ = try IDResolver.resolve(
+        ["3"],
+        from: sampleReminders(),
+        indexedIDs: ["abcd1234", "abce5678"]
+      )
+    }
+  }
+
+  @Test("Cached ID missing from live reminders throws reminderNotFound")
+  func cachedIDDeletedThrows() {
+    #expect(throws: RemindCoreError.reminderNotFound("zzzzzzzz")) {
+      _ = try IDResolver.resolve(
+        ["1"],
+        from: sampleReminders(),
+        indexedIDs: ["zzzzzzzz"]
+      )
+    }
+  }
+
+  @Test("Resolve by prefix works without indexedIDs")
   func resolvePrefix() throws {
     let resolved = try IDResolver.resolve(["abcd"], from: sampleReminders())
     #expect(resolved.first?.title == "First")


### PR DESCRIPTION
Fixes #53.

## Summary

- Cache the displayed reminder IDs (in display order) to `~/Library/Caches/remindctl/index.json` after each `show` / `list <name>`.
- `IDResolver.resolve` takes a new optional `indexedIDs:` parameter; numeric inputs map through it (`indexedIDs[N-1]` → ID → live reminder). With no cache available, numeric inputs throw a friendly `numericIndexWithoutContext` error instead of silently picking the wrong reminder.
- `complete` / `delete` / `edit` pass `IndexCache.load()` as `indexedIDs:`. ID-prefix resolution is unchanged.

`RemindCore` stays filesystem-free — the cache lives in the CLI layer (`Sources/remindctl/IndexCache.swift`); the resolver just receives the IDs as a parameter.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — all 37 tests pass, including new cases in `IDResolverTests` covering numeric-with-cache, numeric-without-cache (throws), out-of-range, and cached-ID-deleted-since-show.
- [x] Manual: `remindctl show` then `remindctl complete 1 --dry-run` previews the same first row that was printed.
- [x] Manual: with cache deleted, `remindctl complete 1` prints the friendly hint pointing at `show`.
- [ ] Reviewer: verify `remindctl list <name>` → `complete N` resolves against the listed set.
- [ ] Reviewer: verify `remindctl show overdue` → `complete 1` resolves against the overdue list.