### PR TITLE
Add --url support to set the reminder URL field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.3.1 - Unreleased
+- Add support for setting the reminder URL field via `--url` on `add`/`edit` and `--clear-url` on `edit` (EKReminder.url; previously exposed read-only in JSON output).
 - Redesign the GitHub Pages documentation site with light/dark mode and a reminder-focused overview.
 
 ## 0.3.0 - 2026-05-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ## 0.3.1 - Unreleased
-- Add support for setting the reminder URL field via `--url` on `add`/`edit` and `--clear-url` on `edit` (EKReminder.url; previously exposed read-only in JSON output).
 - Redesign the GitHub Pages documentation site with light/dark mode and a reminder-focused overview.
 
 ## 0.3.0 - 2026-05-28

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ pnpm build
 remindctl add "Buy milk"
 remindctl add "Call mom" --list Personal --due tomorrow
 remindctl add "Meeting" --due "2026-01-03 09:00" --alarm "2026-01-03 08:55"
+remindctl add "Buy headphones" --url "https://example.com/product"
 
 remindctl today
 remindctl overdue
@@ -49,6 +50,7 @@ remindctl export --list Work --export-format csv
 remindctl link 1
 
 remindctl edit 1 --title "New title" --due 2026-01-04
+remindctl edit 1 --url "https://example.com/product"   # or --clear-url to remove it
 remindctl complete 1 2 3
 remindctl delete 4A83 --force
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -76,6 +76,7 @@ Important options:
 - `--due <date>` set the due date
 - `--alarm <date>` set the alarm date
 - `--notes <text>` add notes
+- `--url <url>` set the dedicated URL field
 - `--repeat <rule>` set simple recurrence
 - `--priority <none|low|medium|high>` set priority
 - `--location <address>` create a location trigger
@@ -95,11 +96,12 @@ Use `--location` whenever using `--radius` or `--leaving`; those flags are inval
 - `--due` or `--clear-due`
 - `--alarm` or `--clear-alarm`
 - `--notes`
+- `--url` or `--clear-url`
 - `--repeat` or `--no-repeat`
 - `--priority`
 - `--complete` or `--incomplete`
 
-Reject conflicting combinations such as `--due` with `--clear-due`, `--alarm` with `--clear-alarm`, `--repeat` with `--no-repeat`, or `--complete` with `--incomplete`.
+Reject conflicting combinations such as `--due` with `--clear-due`, `--alarm` with `--clear-alarm`, `--url` with `--clear-url`, `--repeat` with `--no-repeat`, or `--complete` with `--incomplete`.
 
 Use `remindctl edit <id> --list <new-list>` to move a reminder between lists. Do not tell the user to delete and recreate the reminder for a move; the command already supports moving it directly.
 

--- a/Sources/RemindCore/EventKitStore.swift
+++ b/Sources/RemindCore/EventKitStore.swift
@@ -125,6 +125,7 @@ public actor RemindersStore {
     let reminder = EKReminder(eventStore: eventStore)
     reminder.title = draft.title
     reminder.notes = draft.notes
+    reminder.url = draft.url
     reminder.calendar = calendar
     reminder.priority = draft.priority.eventKitValue
     if let dueDate = draft.dueDate {
@@ -151,9 +152,9 @@ public actor RemindersStore {
     if let title = update.title {
       reminder.title = title
     }
-    if let notes = update.notes {
-      reminder.notes = notes
-    }
+    // Simple optional fields: outer optional present => apply. For url, inner nil clears it.
+    update.notes.map { reminder.notes = $0 }
+    update.url.map { reminder.url = $0 }
     if let dueDateUpdate = update.dueDate {
       if let dueDate = dueDateUpdate {
         reminder.dueDateComponents = nil

--- a/Sources/RemindCore/Models.swift
+++ b/Sources/RemindCore/Models.swift
@@ -164,6 +164,7 @@ public struct ReminderItem: Identifiable, Codable, Sendable, Equatable {
 public struct ReminderDraft: Sendable {
   public let title: String
   public let notes: String?
+  public let url: URL?
   public let dueDate: ParsedUserDate?
   public let alarmDate: ParsedUserDate?
   public let recurrenceRule: RecurrenceRule?
@@ -173,6 +174,7 @@ public struct ReminderDraft: Sendable {
   public init(
     title: String,
     notes: String?,
+    url: URL? = nil,
     dueDate: ParsedUserDate?,
     alarmDate: ParsedUserDate? = nil,
     recurrenceRule: RecurrenceRule? = nil,
@@ -181,6 +183,7 @@ public struct ReminderDraft: Sendable {
   ) {
     self.title = title
     self.notes = notes
+    self.url = url
     self.dueDate = dueDate
     self.alarmDate = alarmDate
     self.recurrenceRule = recurrenceRule
@@ -192,6 +195,8 @@ public struct ReminderDraft: Sendable {
 public struct ReminderUpdate: Sendable {
   public let title: String?
   public let notes: String?
+  // Double optional: nil = leave unchanged, .some(nil) = clear, .some(url) = set.
+  public let url: URL??
   public let dueDate: ParsedUserDate??
   public let alarmDate: ParsedUserDate??
   public let recurrenceRule: RecurrenceRule??
@@ -203,6 +208,7 @@ public struct ReminderUpdate: Sendable {
   public init(
     title: String? = nil,
     notes: String? = nil,
+    url: URL?? = nil,
     dueDate: ParsedUserDate?? = nil,
     alarmDate: ParsedUserDate?? = nil,
     recurrenceRule: RecurrenceRule?? = nil,
@@ -213,6 +219,7 @@ public struct ReminderUpdate: Sendable {
   ) {
     self.title = title
     self.notes = notes
+    self.url = url
     self.dueDate = dueDate
     self.alarmDate = alarmDate
     self.recurrenceRule = recurrenceRule

--- a/Sources/remindctl/CommandHelpers.swift
+++ b/Sources/remindctl/CommandHelpers.swift
@@ -24,6 +24,14 @@ enum CommandHelpers {
     return parsed
   }
 
+  static func parseURL(_ value: String) throws -> URL {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, let url = URL(string: trimmed) else {
+      throw RemindCoreError.operationFailed("Invalid URL: \"\(value)\"")
+    }
+    return url
+  }
+
   static func parseRecurrence(_ value: String) throws -> RecurrenceRule {
     let normalized = value.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
     switch normalized {

--- a/Sources/remindctl/CommandHelpers.swift
+++ b/Sources/remindctl/CommandHelpers.swift
@@ -26,8 +26,13 @@ enum CommandHelpers {
 
   static func parseURL(_ value: String) throws -> URL {
     let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty, let url = URL(string: trimmed) else {
-      throw RemindCoreError.operationFailed("Invalid URL: \"\(value)\"")
+    guard
+      !trimmed.isEmpty,
+      let url = URL(string: trimmed),
+      let scheme = url.scheme,
+      !scheme.isEmpty
+    else {
+      throw RemindCoreError.operationFailed("Invalid URL: \"\(value)\" (include a scheme like https://)")
     }
     return url
   }

--- a/Sources/remindctl/Commands/AddCommand.swift
+++ b/Sources/remindctl/Commands/AddCommand.swift
@@ -33,6 +33,12 @@ enum AddCommand {
             ),
             .make(label: "notes", names: [.short("n"), .long("notes")], help: "Notes", parsing: .singleValue),
             .make(
+              label: "url",
+              names: [.long("url")],
+              help: "URL (Reminders dedicated URL field)",
+              parsing: .singleValue
+            ),
+            .make(
               label: "repeat",
               names: [.short("r"), .long("repeat")],
               help: "daily|weekly|biweekly|monthly|yearly|every N days/weeks/months/years",
@@ -57,6 +63,7 @@ enum AddCommand {
         "remindctl add \"Check mailbox\" --location \"1 Apple Park Way, Cupertino, CA\"",
         "remindctl add \"Take vitamins\" --due tomorrow --repeat daily",
         "remindctl add \"Review docs\" --priority high",
+        "remindctl add \"Buy headphones\" --url \"https://example.com/product\"",
       ]
     ) { values, runtime in
       let titleOption = values.option("title")
@@ -81,6 +88,7 @@ enum AddCommand {
       let listName = values.option("list")
       let listID = values.option("listID")
       let notes = values.option("notes")
+      let url = try values.option("url").map(CommandHelpers.parseURL)
       let dueValue = values.option("due")
       let alarmValue = values.option("alarm")
       let locationValue = values.option("location")
@@ -114,6 +122,7 @@ enum AddCommand {
       let draft = ReminderDraft(
         title: title,
         notes: notes,
+        url: url,
         dueDate: dueDate,
         alarmDate: alarmDate,
         recurrenceRule: recurrenceRule,

--- a/Sources/remindctl/Commands/EditCommand.swift
+++ b/Sources/remindctl/Commands/EditCommand.swift
@@ -22,6 +22,7 @@ enum EditCommand {
             .make(label: "due", names: [.short("d"), .long("due")], help: "Set due date", parsing: .singleValue),
             .make(label: "alarm", names: [.short("a"), .long("alarm")], help: "Set alarm date", parsing: .singleValue),
             .make(label: "notes", names: [.short("n"), .long("notes")], help: "Set notes", parsing: .singleValue),
+            .make(label: "url", names: [.long("url")], help: "Set URL", parsing: .singleValue),
             .make(
               label: "repeat",
               names: [.short("r"), .long("repeat")],
@@ -38,6 +39,7 @@ enum EditCommand {
           flags: [
             .make(label: "clearDue", names: [.long("clear-due")], help: "Clear due date"),
             .make(label: "clearAlarm", names: [.long("clear-alarm")], help: "Clear alarm"),
+            .make(label: "clearUrl", names: [.long("clear-url")], help: "Clear URL"),
             .make(label: "noRepeat", names: [.long("no-repeat")], help: "Remove recurrence"),
             .make(label: "complete", names: [.long("complete")], help: "Mark completed"),
             .make(label: "incomplete", names: [.long("incomplete")], help: "Mark incomplete"),
@@ -51,6 +53,8 @@ enum EditCommand {
         "remindctl edit 4A83 --repeat weekly",
         "remindctl edit 2 --priority high --notes \"Call before noon\"",
         "remindctl edit 3 --clear-due --clear-alarm --no-repeat",
+        "remindctl edit 4A83 --url \"https://example.com/product\"",
+        "remindctl edit 4A83 --clear-url",
       ]
     ) { values, runtime in
       guard let input = values.argument(0) else {
@@ -71,6 +75,17 @@ enum EditCommand {
       let notes = values.option("notes")
       let alarmValue = values.option("alarm")
       let repeatValue = values.option("repeat")
+
+      var urlUpdate: URL??
+      if let urlValue = values.option("url") {
+        urlUpdate = try CommandHelpers.parseURL(urlValue)
+      }
+      if values.flag("clearUrl") {
+        if urlUpdate != nil {
+          throw RemindCoreError.operationFailed("Use either --url or --clear-url, not both")
+        }
+        urlUpdate = .some(nil)
+      }
 
       var dueUpdate: ParsedUserDate??
       if let dueValue = values.option("due") {
@@ -120,8 +135,8 @@ enum EditCommand {
       let targetList = try CommandHelpers.listTarget(name: listName, id: listID)
 
       let hasChanges =
-        title != nil || targetList != nil || notes != nil || dueUpdate != nil || alarmUpdate != nil || priority != nil
-        || recurrenceUpdate != nil || isCompleted != nil
+        title != nil || targetList != nil || notes != nil || urlUpdate != nil || dueUpdate != nil
+        || alarmUpdate != nil || priority != nil || recurrenceUpdate != nil || isCompleted != nil
       if !hasChanges {
         throw RemindCoreError.operationFailed("No changes specified")
       }
@@ -129,6 +144,7 @@ enum EditCommand {
       let update = ReminderUpdate(
         title: title,
         notes: notes,
+        url: urlUpdate,
         dueDate: dueUpdate,
         alarmDate: alarmUpdate,
         recurrenceRule: recurrenceUpdate,

--- a/Sources/remindctl/Commands/EditCommand.swift
+++ b/Sources/remindctl/Commands/EditCommand.swift
@@ -76,16 +76,7 @@ enum EditCommand {
       let alarmValue = values.option("alarm")
       let repeatValue = values.option("repeat")
 
-      var urlUpdate: URL??
-      if let urlValue = values.option("url") {
-        urlUpdate = try CommandHelpers.parseURL(urlValue)
-      }
-      if values.flag("clearUrl") {
-        if urlUpdate != nil {
-          throw RemindCoreError.operationFailed("Use either --url or --clear-url, not both")
-        }
-        urlUpdate = .some(nil)
-      }
+      let urlUpdate = try parsedURLUpdate(urlValue: values.option("url"), clearURL: values.flag("clearUrl"))
 
       var dueUpdate: ParsedUserDate??
       if let dueValue = values.option("due") {
@@ -156,5 +147,15 @@ enum EditCommand {
       let updated = try await store.updateReminder(id: reminder.id, update: update)
       OutputRenderer.printReminder(updated, format: runtime.outputFormat)
     }
+  }
+
+  static func parsedURLUpdate(urlValue: String?, clearURL: Bool) throws -> URL?? {
+    if let urlValue {
+      if clearURL {
+        throw RemindCoreError.operationFailed("Use either --url or --clear-url, not both")
+      }
+      return try CommandHelpers.parseURL(urlValue)
+    }
+    return clearURL ? .some(nil) : nil
   }
 }

--- a/Tests/RemindCoreTests/ModelsTests.swift
+++ b/Tests/RemindCoreTests/ModelsTests.swift
@@ -13,6 +13,24 @@ struct ModelsTests {
     #expect(RecurrenceRule(frequency: .yearly, interval: 4).displayString == "every 4 years")
   }
 
+  @Test("Reminder draft and update carry the url field")
+  func urlField() {
+    let url = URL(string: "https://example.com/product")!
+
+    // Draft: explicit url is preserved; default is nil.
+    let draft = ReminderDraft(title: "Buy", notes: nil, url: url, dueDate: nil, priority: .none)
+    #expect(draft.url == url)
+    #expect(ReminderDraft(title: "Buy", notes: nil, dueDate: nil, priority: .none).url == nil)
+
+    // Update double-optional: nil = leave, .some(nil) = clear, .some(url) = set.
+    #expect(ReminderUpdate(title: "x").url == nil)
+    let setUpdate = ReminderUpdate(url: .some(url))
+    #expect(setUpdate.url! == url)
+    let clearUpdate = ReminderUpdate(url: .some(nil))
+    #expect(clearUpdate.url != nil)
+    #expect(clearUpdate.url! == nil)
+  }
+
   @Test("Model initializers preserve defaults and explicit values")
   func initializerDefaults() {
     let date = Date(timeIntervalSince1970: 1_700_000_000)

--- a/Tests/remindctlTests/HelpPrinterTests.swift
+++ b/Tests/remindctlTests/HelpPrinterTests.swift
@@ -34,17 +34,20 @@ struct HelpPrinterTests {
     #expect(joined.contains("completion"))
   }
 
-  @Test("Add and edit help include alarm, location, and repeat options")
-  func alarmLocationAndRepeatHelp() {
+  @Test("Add and edit help include alarm, location, repeat, and URL options")
+  func alarmLocationRepeatAndURLHelp() {
     let addHelp = HelpPrinter.renderCommand(rootName: "remindctl", spec: AddCommand.spec).joined(separator: "\n")
     let editHelp = HelpPrinter.renderCommand(rootName: "remindctl", spec: EditCommand.spec).joined(separator: "\n")
 
     #expect(addHelp.contains("--alarm"))
     #expect(addHelp.contains("--location"))
     #expect(addHelp.contains("--leaving"))
+    #expect(addHelp.contains("--url"))
     #expect(addHelp.contains("--repeat"))
     #expect(editHelp.contains("--alarm"))
     #expect(editHelp.contains("--clear-alarm"))
+    #expect(editHelp.contains("--url"))
+    #expect(editHelp.contains("--clear-url"))
     #expect(editHelp.contains("--repeat"))
     #expect(editHelp.contains("--no-repeat"))
   }

--- a/Tests/remindctlTests/URLCommandTests.swift
+++ b/Tests/remindctlTests/URLCommandTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+
+@testable import remindctl
+
+struct URLCommandTests {
+  @Test("URL parsing requires an explicit scheme")
+  func parseURLRequiresScheme() throws {
+    let url = try CommandHelpers.parseURL("https://example.com/product")
+    #expect(url.absoluteString == "https://example.com/product")
+
+    #expect(throws: Error.self) {
+      _ = try CommandHelpers.parseURL("example.com/product")
+    }
+    #expect(throws: Error.self) {
+      _ = try CommandHelpers.parseURL("   ")
+    }
+  }
+
+  @Test("Edit URL update preserves set clear and leave semantics")
+  func editURLUpdateSemantics() throws {
+    let setUpdate = try EditCommand.parsedURLUpdate(urlValue: "https://example.com/product", clearURL: false)
+    #expect(setUpdate != nil)
+    #expect(setUpdate!! == URL(string: "https://example.com/product")!)
+
+    let clearUpdate = try EditCommand.parsedURLUpdate(urlValue: nil, clearURL: true)
+    #expect(clearUpdate != nil)
+    #expect(clearUpdate! == nil)
+
+    let noChange = try EditCommand.parsedURLUpdate(urlValue: nil, clearURL: false)
+    #expect(noChange == nil)
+  }
+
+  @Test("Edit URL update rejects conflicting set and clear flags")
+  func editURLUpdateRejectsConflict() {
+    #expect(throws: Error.self) {
+      _ = try EditCommand.parsedURLUpdate(urlValue: "https://example.com/product", clearURL: true)
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds the ability to set the dedicated Reminders **URL field** (`EKCalendarItem.url`, inherited by `EKReminder`) from the CLI:

- `add --url <value>` and `edit --url <value>` set the URL.
- `edit --clear-url` clears it (mirrors `--clear-due` / `--clear-alarm`; rejects combining `--url` with `--clear-url`).

## Why

The URL field is the natural home for a link attached to a reminder (e.g. a product link on a shopping item) rather than burying it in notes. `remindctl` already **reads** the field — 0.3.0 exposes `url` in JSON/export output — but there was no way to write it. This closes that gap.

## Implementation

- `ReminderDraft` gains `url: URL?`; `ReminderUpdate` gains `url: URL??` using the existing double-optional convention (`nil` = leave unchanged, `.some(nil)` = clear, `.some(url)` = set), matching how `dueDate`/`alarmDate` already work.
- `EventKitStore` sets `reminder.url` on create and update.
- `CommandHelpers.parseURL` now requires an explicit scheme so relative strings like `example.com` are rejected instead of being stored as ambiguous relative URLs.
- Since the field was already plumbed read-side, this is a small write-path addition.
- Minor: the adjacent `notes` update assignment was converted to the same `.map` one-liner as `url`, for consistency (identical behavior).
- Maintainer follow-up commit `8162390` removes the release-owned changelog edit and adds command-level URL regressions.

## Tests / verification

- New model and command-level tests cover URL set/clear/leave semantics, `--url` / `--clear-url` help exposure, and absolute-URL validation.
- `make check`
- `autoreview --mode branch --base origin/main`
- Live EventKit proof on macOS using the committed release build (`bin/remindctl`) and a disposable list `remindctl-url-proof-20260611-020323-17587`:

```text
$ ./bin/remindctl add "remindctl url proof 20260611-020323-17587" --list-id 652BB23C-5D32-4F23-9EA9-7B6268949CFE --url https://example.com/20260611-020323-17587/add --json
... "url": "https://example.com/20260611-020323-17587/add"

$ ./bin/remindctl info 10725902-675C-419F-A691-E2DF3838806B --json
... "url": "https://example.com/20260611-020323-17587/add"

$ ./bin/remindctl edit 10725902-675C-419F-A691-E2DF3838806B --url https://example.com/20260611-020323-17587/edit --json
... "url": "https://example.com/20260611-020323-17587/edit"

$ ./bin/remindctl edit 10725902-675C-419F-A691-E2DF3838806B --clear-url --json
... no `url` field

$ ./bin/remindctl export --list-id 652BB23C-5D32-4F23-9EA9-7B6268949CFE --json
... item exported without a `url` field after clear

$ ./bin/remindctl delete 10725902-675C-419F-A691-E2DF3838806B --force --json
{"deleted":1}

$ ./bin/remindctl list --list-id 652BB23C-5D32-4F23-9EA9-7B6268949CFE --json
[]

$ ./bin/remindctl list --list-id 652BB23C-5D32-4F23-9EA9-7B6268949CFE --delete --force
Deleted list "remindctl-url-proof-20260611-020323-17587"
```

Docs updated: README quick-start, SKILL.md option lists.
