### PR TITLE
Build universal macOS release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,23 +46,8 @@ jobs:
       - name: Resolve packages
         run: swift package resolve
 
-      - name: Sync version
-        run: scripts/generate-version.sh
-
-      - name: Build
-        run: swift build -c release --product remindctl
-
-      - name: Codesign
-        run: codesign --force --sign - --identifier com.steipete.remindctl .build/release/remindctl
-
-      - name: Package artifact
-        run: |
-          mkdir -p dist
-          cp .build/release/remindctl dist/remindctl
-          (
-            cd dist
-            zip -r remindctl-macos.zip remindctl
-          )
+      - name: Package universal macOS artifact
+        run: scripts/package-macos-release.sh
 
       - name: Extract release notes from CHANGELOG
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.3.2 - Unreleased
+- Build the release archive as a universal arm64/x86_64 macOS binary and verify both slices before publishing; thanks @TurboTheTurtle.
 
 ## 0.3.1 - 2026-06-11
 - Add support for setting the reminder URL field via `--url` on `add`/`edit` and `--clear-url` on `edit`; thanks @jeremylahners.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: help format lint test check build remindctl release-check docs-site clean
+.PHONY: help format lint test check build macos-artifact remindctl release-check docs-site clean
 
 help:
 	@printf "%s\n" \
@@ -9,6 +9,7 @@ help:
 		"make test      - sync version + swift test (coverage enabled)" \
 		"make check     - lint + test + coverage gate" \
 		"make build     - release build into bin/ (codesigned)" \
+		"make macos-artifact - build universal dist/remindctl-macos.zip" \
 		"make release-check TAG=vX.Y.Z - validate release preflight" \
 		"make remindctl - clean rebuild + run debug binary (ARGS=...)" \
 		"make docs-site - build GitHub Pages docs into dist/docs-site" \
@@ -36,6 +37,9 @@ build:
 	swift build -c release --product remindctl
 	cp .build/release/remindctl bin/remindctl
 	codesign --force --sign - --identifier com.steipete.remindctl bin/remindctl
+
+macos-artifact:
+	scripts/package-macos-release.sh
 
 release-check:
 	@if [ -z "$(TAG)" ]; then echo "Usage: make release-check TAG=vX.Y.Z" >&2; exit 1; fi

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -10,13 +10,14 @@
    - Run `scripts/generate-version.sh` (refreshes `Sources/remindctl/Version.swift` + embedded Info.plist).
 2. Ensure checks are green
    - `make check` (strict lint, tests, and the 90% coverage gate)
+   - `make macos-artifact` (builds `dist/remindctl-macos.zip` and verifies it contains arm64 + x86_64 slices)
    - `make release-check TAG=vX.Y.Z`
 3. Commit and tag
    - `git tag -a vX.Y.Z -m "vX.Y.Z"`
    - `git push origin vX.Y.Z`
 4. Autorelease
    - Pushing `v*` tags runs `.github/workflows/release.yml`.
-   - The workflow builds `remindctl-macos.zip`, creates or updates the GitHub Release, replaces release notes from the matching `CHANGELOG.md` section, then dispatches the Homebrew tap formula updater.
+   - The workflow builds a universal `remindctl-macos.zip`, verifies the archive contains arm64 + x86_64 slices, creates or updates the GitHub Release, replaces release notes from the matching `CHANGELOG.md` section, then dispatches the Homebrew tap formula updater.
    - Requires `HOMEBREW_TAP_TOKEN` with workflow dispatch access to `steipete/homebrew-tap`.
 
 ## Manual rerun
@@ -25,5 +26,5 @@
 
 ## What happens in CI
 - `.github/workflows/release.yml` runs on pushed `v*` tags and manual dispatch.
-- The GitHub-hosted artifact is ad-hoc signed for Homebrew distribution.
+- The GitHub-hosted artifact is a universal macOS binary and is ad-hoc signed for Homebrew distribution.
 - `scripts/sign-and-notarize.sh` remains available for local notarized builds when needed.

--- a/scripts/build-macos-universal.sh
+++ b/scripts/build-macos-universal.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <output-binary>" >&2
+  exit 1
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT="$1"
+ARCHES_VALUE=${ARCHES:-"arm64 x86_64"}
+read -r -a ARCH_LIST <<< "$ARCHES_VALUE"
+
+if [[ ${#ARCH_LIST[@]} -eq 0 ]]; then
+  echo "ARCHES must include at least one architecture" >&2
+  exit 1
+fi
+
+if [[ "${SKIP_VERSION_SYNC:-0}" != "1" ]]; then
+  "$ROOT/scripts/generate-version.sh"
+fi
+
+mkdir -p "$(dirname "$OUTPUT")"
+
+BINARIES=()
+for ARCH in "${ARCH_LIST[@]}"; do
+  swift build -c release --product remindctl --arch "$ARCH"
+
+  BINARY="$ROOT/.build/${ARCH}-apple-macosx/release/remindctl"
+  if [[ ! -f "$BINARY" ]]; then
+    echo "Expected build output not found: $BINARY" >&2
+    exit 1
+  fi
+
+  BINARIES+=("$BINARY")
+done
+
+lipo -create "${BINARIES[@]}" -output "$OUTPUT"
+lipo "$OUTPUT" -verify_arch "${ARCH_LIST[@]}"
+lipo -info "$OUTPUT"

--- a/scripts/build-macos-universal.sh
+++ b/scripts/build-macos-universal.sh
@@ -24,9 +24,14 @@ mkdir -p "$(dirname "$OUTPUT")"
 
 BINARIES=()
 for ARCH in "${ARCH_LIST[@]}"; do
-  swift build -c release --product remindctl --arch "$ARCH"
+  SCRATCH_PATH="$ROOT/.build/$ARCH"
+  swift build -c release --product remindctl --arch "$ARCH" --scratch-path "$SCRATCH_PATH"
 
-  BINARY="$ROOT/.build/${ARCH}-apple-macosx/release/remindctl"
+  BIN_PATH="$(
+    swift build -c release --product remindctl --arch "$ARCH" \
+      --scratch-path "$SCRATCH_PATH" --show-bin-path
+  )"
+  BINARY="$BIN_PATH/remindctl"
   if [[ ! -f "$BINARY" ]]; then
     echo "Expected build output not found: $BINARY" >&2
     exit 1
@@ -36,5 +41,7 @@ for ARCH in "${ARCH_LIST[@]}"; do
 done
 
 lipo -create "${BINARIES[@]}" -output "$OUTPUT"
-lipo "$OUTPUT" -verify_arch "${ARCH_LIST[@]}"
+for ARCH in "${ARCH_LIST[@]}"; do
+  lipo "$OUTPUT" -verify_arch "$ARCH"
+done
 lipo -info "$OUTPUT"

--- a/scripts/check-macos-artifact.sh
+++ b/scripts/check-macos-artifact.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <remindctl-binary-or-zip>" >&2
+  exit 1
+fi
+
+ARTIFACT="$1"
+ARCHES_VALUE=${ARCHES:-"arm64 x86_64"}
+read -r -a ARCH_LIST <<< "$ARCHES_VALUE"
+
+if [[ ${#ARCH_LIST[@]} -eq 0 ]]; then
+  echo "ARCHES must include at least one architecture" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/remindctl-artifact.XXXXXX")"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+if [[ "$ARTIFACT" == *.zip ]]; then
+  unzip -q "$ARTIFACT" -d "$TMP_DIR"
+  BINARY="$TMP_DIR/remindctl"
+else
+  BINARY="$ARTIFACT"
+fi
+
+if [[ ! -f "$BINARY" ]]; then
+  echo "Expected remindctl binary not found in artifact: $ARTIFACT" >&2
+  exit 1
+fi
+
+lipo "$BINARY" -verify_arch "${ARCH_LIST[@]}"
+lipo -info "$BINARY"
+file "$BINARY"

--- a/scripts/check-macos-artifact.sh
+++ b/scripts/check-macos-artifact.sh
@@ -33,6 +33,8 @@ if [[ ! -f "$BINARY" ]]; then
   exit 1
 fi
 
-lipo "$BINARY" -verify_arch "${ARCH_LIST[@]}"
+for ARCH in "${ARCH_LIST[@]}"; do
+  lipo "$BINARY" -verify_arch "$ARCH"
+done
 lipo -info "$BINARY"
 file "$BINARY"

--- a/scripts/package-macos-release.sh
+++ b/scripts/package-macos-release.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR=${OUTPUT_DIR:-"$ROOT/dist"}
+ZIP_PATH=${ZIP_PATH:-"$OUTPUT_DIR/remindctl-macos.zip"}
+CODESIGN_IDENTITY=${CODESIGN_IDENTITY:-"-"}
+CODESIGN_IDENTIFIER=${CODESIGN_IDENTIFIER:-"com.steipete.remindctl"}
+DITTO_BIN=${DITTO_BIN:-/usr/bin/ditto}
+STAGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/remindctl-dist.XXXXXX")"
+
+cleanup() {
+  rm -rf "$STAGE_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$OUTPUT_DIR"
+rm -f "$OUTPUT_DIR/remindctl" "$ZIP_PATH"
+
+"$ROOT/scripts/build-macos-universal.sh" "$OUTPUT_DIR/remindctl"
+
+codesign --force --sign "$CODESIGN_IDENTITY" \
+  --identifier "$CODESIGN_IDENTIFIER" \
+  "$OUTPUT_DIR/remindctl"
+codesign --verify --strict --verbose=2 "$OUTPUT_DIR/remindctl"
+
+cp "$OUTPUT_DIR/remindctl" "$STAGE_DIR/remindctl"
+(
+  cd "$STAGE_DIR"
+  "$DITTO_BIN" --norsrc -c -k remindctl "$ZIP_PATH"
+)
+
+"$ROOT/scripts/check-macos-artifact.sh" "$ZIP_PATH"
+echo "Done: $ZIP_PATH"
+

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -2,15 +2,12 @@
 set -euo pipefail
 
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
-source "$ROOT/version.env"
 
 APP_NAME="remindctl"
 CODESIGN_IDENTITY=${CODESIGN_IDENTITY:-"Developer ID Application: Peter Steinberger (Y5PE65HELJ)"}
 ENTITLEMENTS="${ROOT}/Resources/remindctl.entitlements"
 OUTPUT_DIR=${OUTPUT_DIR:-/tmp}
 ZIP_PATH="${OUTPUT_DIR}/remindctl-macos.zip"
-ARCHES_VALUE=${ARCHES:-"arm64 x86_64"}
-ARCH_LIST=( ${ARCHES_VALUE} )
 DIST_DIR="$(mktemp -d "/tmp/${APP_NAME}-dist.XXXXXX")"
 API_KEY_FILE="$(mktemp "/tmp/${APP_NAME}-notary.XXXXXX.p8")"
 
@@ -27,18 +24,7 @@ fi
 
 echo "$APP_STORE_CONNECT_API_KEY_P8" | sed 's/\\n/\n/g' > "$API_KEY_FILE"
 
-"$ROOT/scripts/generate-version.sh"
-
-for ARCH in "${ARCH_LIST[@]}"; do
-  swift build -c release --product remindctl --arch "$ARCH"
-done
-
-BINARIES=()
-for ARCH in "${ARCH_LIST[@]}"; do
-  BINARIES+=("$ROOT/.build/${ARCH}-apple-macosx/release/remindctl")
-done
-
-lipo -create "${BINARIES[@]}" -output "$DIST_DIR/remindctl"
+"$ROOT/scripts/build-macos-universal.sh" "$DIST_DIR/remindctl"
 
 if [[ -f "$ENTITLEMENTS" ]]; then
   codesign --force --timestamp --options runtime --sign "$CODESIGN_IDENTITY" \
@@ -69,5 +55,6 @@ codesign --verify --strict --verbose=4 "$DIST_DIR/remindctl"
 if ! spctl -a -t exec -vv "$DIST_DIR/remindctl"; then
   echo "spctl check failed (CLI binaries often report 'not an app')." >&2
 fi
+"$ROOT/scripts/check-macos-artifact.sh" "$ZIP_PATH"
 
 echo "Done: $ZIP_PATH"


### PR DESCRIPTION
Closes #57.

Builds the macOS release artifact through a shared universal binary packaging script so the Homebrew-consumed zip contains both arm64 and x86_64 slices. The release workflow now validates the packaged archive with lipo/file checks, and the notarization helper reuses the same universal build path.

Real behavior proof:
- Real environment tested: macOS 27.0 (26A5353q), arm64 host, Xcode 26.5, Swift 6.3.2.
- Exact steps or command run after this patch: `make macos-artifact`; unzip `dist/remindctl-macos.zip`; run `file`, `lipo -info`, and `scripts/check-macos-artifact.sh dist/remindctl-macos.zip` on the generated archive.
- Evidence after fix: the archive extracted to one top-level `remindctl` binary; `file` reported `Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64:Mach-O 64-bit executable arm64]`; `lipo -info` reported `Architectures in the fat file ... are: x86_64 arm64`.
- Observed result after fix: `scripts/check-macos-artifact.sh dist/remindctl-macos.zip` passed.
- What was not tested: execution on physical Intel Mac hardware and notarized release upload.