### PR TITLE
[codex] support Swift 6.4 coverage report paths

### DIFF
--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -16,13 +16,13 @@ echo "==> swift test --enable-code-coverage (isolated build dir)"
 swift test --enable-code-coverage --build-path "${COVERAGE_BUILD_PATH}" --cache-path "${CACHE_PATH}" >/dev/null
 
 REPORT_JSON="$(
-  find "${COVERAGE_BUILD_PATH}" -type f -path "*debug/codecov/remindctl.json" -print0 2>/dev/null \
+  find "${COVERAGE_BUILD_PATH}" -type f -path "*/codecov/remindctl.json" -print0 2>/dev/null \
     | xargs -0 ls -t 2>/dev/null \
     | head -n 1
 )"
 
 if [ -z "${REPORT_JSON}" ] || [ ! -f "${REPORT_JSON}" ]; then
-  echo "ERROR: Coverage report not found (expected .build/**/debug/codecov/remindctl.json)." >&2
+  echo "ERROR: Coverage report not found (expected .build/**/codecov/remindctl.json)." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- find SwiftPM's coverage JSON by its stable `codecov/remindctl.json` suffix
- accept both legacy lowercase `debug` and current Swift 6.4 `Products/Debug` output layouts

## Root cause

`scripts/check-coverage.sh` hardcoded a lowercase `debug` path component. Swift 6.4's current build system writes the same report under `.build/coverage/out/Products/Debug/codecov`, so the 90% gate failed after otherwise successful tests.

## Validation

- `bash -n scripts/check-coverage.sh`
- `scripts/check-coverage.sh` — 92.5% (515/557), 90% minimum
- `git diff --check`
