### PR TITLE
ci: update checkout action to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Swift version
         run: swift --version
       - name: Install SwiftLint

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.2 - Unreleased
 - Make `--url` visible in Reminders.app by retaining the EventKit URL and mirroring one managed notes link; `--clear-url` removes only that link; thanks @TurboTheTurtle.
 - Build the release archive as a universal arm64/x86_64 macOS binary and verify both slices before publishing; thanks @TurboTheTurtle.
+- Update GitHub Actions workflows to `actions/checkout@v7` for current dependency and fork-checkout security fixes.
 
 ## 0.3.1 - 2026-06-11
 - Add support for setting the reminder URL field via `--url` on `add`/`edit` and `--clear-url` on `edit`; thanks @jeremylahners.


### PR DESCRIPTION
## Summary

- Update every workflow use of `actions/checkout` from v6 to v7.
- Record the maintenance update in the 0.3.2 changelog.

## Dependency review

- Stable upstream: https://github.com/actions/checkout/releases/tag/v7.0.0 (released 2026-06-18).
- Compatibility: v6 and v7 both use Node 24; existing inputs remain valid, including `fetch-depth: 0` in the release workflow.
- Security/health: v7 adds safer fork checkout handling plus dependency security fixes; this repository does not use the affected `pull_request_target` or `workflow_run` checkout pattern. Upstream's release commit passed macOS, Linux, Windows, proxy, build, dist, license, and CodeQL checks.
- Other direct dependencies: Commander 0.2.2 and the remaining GitHub Actions major tags are current stable releases.

## Proof

- `actionlint .github/workflows/*.yml`
- `make check`: strict format/SwiftLint; 65 tests; RemindCore coverage 91.1% (613/673; 90% required)
- `make docs-site`
- `make macos-artifact`: verified universal x86_64 + arm64 archive
- Autoreview (`--mode local`, Codex): clean; no accepted/actionable findings

Metadata/CI-only change; no Reminders runtime behavior or external live boundary changed. No release, version bump, tag, or publishing action included.
