### PR TITLE
fix(store): bound EventKit fetchReminders with a 30s timeout

### DIFF
--- a/Sources/RemindCore/EventKitStore.swift
+++ b/Sources/RemindCore/EventKitStore.swift
@@ -72,7 +72,7 @@ public actor RemindersStore {
   }
 
   public func reminders(matching target: ReminderListTarget?) async throws -> [ReminderItem] {
-    await fetchReminders(in: try calendars(matching: target))
+    try await fetchReminders(in: try calendars(matching: target))
   }
 
   public func createList(name: String) async throws -> ReminderList {
@@ -219,7 +219,7 @@ extension RemindersStore {
     }
   }
 
-  private func fetchReminders(in calendars: [EKCalendar]) async -> [ReminderItem] {
+  private func fetchReminders(in calendars: [EKCalendar]) async throws -> [ReminderItem] {
     struct ReminderData: Sendable {
       let id: String
       let title: String
@@ -239,7 +239,36 @@ extension RemindersStore {
       let listName: String
     }
 
-    let reminderData = await withCheckedContinuation { (continuation: CheckedContinuation<[ReminderData], Never>) in
+    // EventKit's callback can stall indefinitely; bound the wait so list/CLI cannot hang forever.
+    let fetchTimeoutNanoseconds: UInt64 = 30_000_000_000
+    let reminderData = try await withCheckedThrowingContinuation {
+      (continuation: CheckedContinuation<[ReminderData], Error>) in
+      final class OnceResume: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<[ReminderData], Error>?
+
+        init(_ continuation: CheckedContinuation<[ReminderData], Error>) {
+          self.continuation = continuation
+        }
+
+        func resume(returning value: [ReminderData]) {
+          lock.lock()
+          defer { lock.unlock() }
+          guard let continuation else { return }
+          self.continuation = nil
+          continuation.resume(returning: value)
+        }
+
+        func resume(throwing error: Error) {
+          lock.lock()
+          defer { lock.unlock() }
+          guard let continuation else { return }
+          self.continuation = nil
+          continuation.resume(throwing: error)
+        }
+      }
+
+      let once = OnceResume(continuation)
       let predicate = eventStore.predicateForReminders(in: calendars)
       eventStore.fetchReminders(matching: predicate) { reminders in
         let data = (reminders ?? []).map { reminder in
@@ -263,7 +292,15 @@ extension RemindersStore {
             listName: reminder.calendar.title
           )
         }
-        continuation.resume(returning: data)
+        once.resume(returning: data)
+      }
+      Task {
+        try await Task.sleep(nanoseconds: fetchTimeoutNanoseconds)
+        once.resume(
+          throwing: RemindCoreError.operationFailed(
+            "Timed out waiting for EventKit reminders after 30s"
+          )
+        )
       }
     }
 

--- a/Sources/RemindCore/EventKitStore.swift
+++ b/Sources/RemindCore/EventKitStore.swift
@@ -239,7 +239,10 @@ extension RemindersStore {
       let listName: String
     }
 
-    // EventKit's callback can stall indefinitely; bound the wait so list/CLI cannot hang forever.
+    // EventKit's callback can stall indefinitely. Contract: wait at most 30s for
+    // the callback. Success cancels the watchdog. If the deadline fires first,
+    // fail with operationFailed so list/CLI cannot hang forever (slow-but-valid
+    // reads that exceed 30s are intentionally treated as failure).
     let fetchTimeoutNanoseconds: UInt64 = 30_000_000_000
     let reminderData = try await withCheckedThrowingContinuation {
       (continuation: CheckedContinuation<[ReminderData], Error>) in
@@ -270,7 +273,21 @@ extension RemindersStore {
 
       let once = OnceResume(continuation)
       let predicate = eventStore.predicateForReminders(in: calendars)
+      let timeoutTask = Task {
+        do {
+          try await Task.sleep(nanoseconds: fetchTimeoutNanoseconds)
+        } catch {
+          // Cancelled when the EventKit callback wins first.
+          return
+        }
+        once.resume(
+          throwing: RemindCoreError.operationFailed(
+            "Timed out waiting for EventKit reminders after 30s"
+          )
+        )
+      }
       eventStore.fetchReminders(matching: predicate) { reminders in
+        timeoutTask.cancel()
         let data = (reminders ?? []).map { reminder in
           let components = reminder.dueDateComponents
           return ReminderData(
@@ -293,14 +310,6 @@ extension RemindersStore {
           )
         }
         once.resume(returning: data)
-      }
-      Task {
-        try await Task.sleep(nanoseconds: fetchTimeoutNanoseconds)
-        once.resume(
-          throwing: RemindCoreError.operationFailed(
-            "Timed out waiting for EventKit reminders after 30s"
-          )
-        )
       }
     }
 


### PR DESCRIPTION
## What Problem This Solves

`fetchReminders` used an unbounded EventKit callback wait. If EventKit never invokes the callback, `remindctl list` (and any path that loads reminders) hangs forever.

## Evidence

### After

- Throwing continuation with one-shot resume helper
- Watchdog `Task.sleep` of 30s resumes `operationFailed("Timed out waiting for EventKit reminders after 30s")` only if it wins the race
- Successful EventKit callback cancels the timeout task first, then resumes with data
- Late resumes after the first win are ignored

```console
$ swift build
Build complete! (9.11s)
```

## Timeout policy (intentional)

| Outcome | Behavior |
|---|---|
| EventKit callback within 30s | Success; timeout task cancelled |
| No callback within 30s | `RemindCoreError.operationFailed` timeout; hang stopped |
| Callback after deadline already fired | Ignored (one-shot resume); timeout already won |

Slow-but-valid EventKit reads that exceed 30s are intentionally treated as failure so list/export cannot hang indefinitely. That is a compatibility change from unbounded wait, accepted for hang protection.

## Real behavior proof

- **Behavior or issue addressed:** Bound EventKit reminder fetch so list cannot hang indefinitely, and cancel the timeout watchdog when the callback wins.
- **Real environment tested:** macOS arm64, worktree `/tmp/remindctl-66` on `fix/eventkit-fetch-timeout`.
- **Exact steps or command run after this patch:** `swift build` after watchdog-cancel change.
- **Evidence after fix:** build complete; `fetchReminders` starts timeout Task, cancels it in the EventKit callback path, sleeps only until cancel or 30s for hang case.
- **Observed result after fix:** Success path does not leave an unstructured 30s sleeper; timeout path still fails closed after 30s.
- **What was not tested:** Live EventKit stall (would need a stuck or mocked EKEventStore); full XCTest suite not run in this session.

## Summary

30s hang bound around EventKit `fetchReminders` with one-shot resume and cancelled watchdog on success.
