### PR TITLE
fix: bound EventKit operations with shared timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Bound EventKit reminder fetches and Core Location geocoding to 30 seconds so stalled system callbacks fail instead of hanging the CLI; thanks @SebTardif and @vincentkoc.
+
 ## 0.3.3 - 2026-07-09
 - Keep every alarm unchanged for due-only edits, and preserve relative and location alarms when `edit --alarm` or `edit --clear-alarm` replaces or clears absolute alarms.
 - Ship official macOS archives as universal hardened-runtime binaries signed by OpenClaw Foundation, notarized locally, verified with the standalone-binary notarization constraint, and Gatekeeper-tested through naturally quarantined clean-VM execution before publication.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "a669a19d7dad51d9569b07c55a81b6066ee617b2f82a0f83681682c9ff35bc10",
+  "originHash" : "d1cb13c1640dc8cb50d58a7784a7c829ba3087e0652eaa17b387fd44e2e845db",
   "pins" : [
     {
       "identity" : "commander",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steipete/Commander.git",
       "state" : {
-        "revision" : "ae2ce746b386ff94b26648cfe5625cfa8d02639b",
-        "version" : "0.2.2"
+        "revision" : "bd219c4ee9032fee3e009856f81fcc6ec09a85f4",
+        "version" : "0.2.4"
       }
     }
   ],

--- a/Sources/RemindCore/AsyncTimeout.swift
+++ b/Sources/RemindCore/AsyncTimeout.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+enum AsyncTimeout {
+  typealias Cancellation = @Sendable () -> Void
+
+  final class Completion<Value: Sendable>: @unchecked Sendable {
+    private let state: AsyncTimeoutState<Value>
+
+    fileprivate init(state: AsyncTimeoutState<Value>) {
+      self.state = state
+    }
+
+    /// Claim the operation result before doing synchronous result conversion.
+    func claim() -> Claim<Value>? {
+      state.claim() ? Claim(state: state) : nil
+    }
+
+    func resume(with result: Result<Value, any Error>) {
+      claim()?.resume(with: result)
+    }
+
+    func resume(returning value: Value) {
+      resume(with: .success(value))
+    }
+
+    func resume(throwing error: any Error) {
+      resume(with: .failure(error))
+    }
+  }
+
+  struct Claim<Value: Sendable>: @unchecked Sendable {
+    private let state: AsyncTimeoutState<Value>
+
+    fileprivate init(state: AsyncTimeoutState<Value>) {
+      self.state = state
+    }
+
+    func resume(with result: Result<Value, any Error>) {
+      state.finish(with: result)
+    }
+
+    func resume(returning value: Value) {
+      resume(with: .success(value))
+    }
+
+    func resume(throwing error: any Error) {
+      resume(with: .failure(error))
+    }
+  }
+
+  nonisolated(nonsending) static func withTimeout<Value: Sendable>(
+    after duration: Duration,
+    timeoutError: RemindCoreError,
+    start: (Completion<Value>) -> Cancellation?
+  ) async throws -> Value {
+    let state = AsyncTimeoutState<Value>()
+
+    return try await withTaskCancellationHandler {
+      try await withCheckedThrowingContinuation { continuation in
+        state.install(continuation)
+        state.installCancellation(start(Completion(state: state)))
+
+        let timeoutTask = Task {
+          do {
+            try await Task.sleep(for: duration)
+          } catch {
+            return
+          }
+          state.timeout(with: timeoutError)
+        }
+        state.installTimeoutTask(timeoutTask)
+      }
+    } onCancel: {
+      state.cancel()
+    }
+  }
+}
+
+private final class AsyncTimeoutState<Value: Sendable>: @unchecked Sendable {
+  private enum Phase {
+    case waiting
+    case claimed
+    case finished
+  }
+
+  private let lock = NSLock()
+  private var phase = Phase.waiting
+  private var continuation: CheckedContinuation<Value, any Error>?
+  private var pendingResult: Result<Value, any Error>?
+  private var timeoutTask: Task<Void, Never>?
+  private var cancellation: AsyncTimeout.Cancellation?
+  private var shouldCancelOperation = false
+
+  func install(_ continuation: CheckedContinuation<Value, any Error>) {
+    let pendingResult = lock.withLock { () -> Result<Value, any Error>? in
+      guard let pendingResult = self.pendingResult else {
+        self.continuation = continuation
+        return nil
+      }
+      self.pendingResult = nil
+      return pendingResult
+    }
+    if let pendingResult {
+      continuation.resume(with: pendingResult)
+    }
+  }
+
+  func installCancellation(_ cancellation: AsyncTimeout.Cancellation?) {
+    let cancellationToRun = lock.withLock {
+      guard phase != .finished else {
+        return shouldCancelOperation ? cancellation : nil
+      }
+      self.cancellation = cancellation
+      return nil
+    }
+    cancellationToRun?()
+  }
+
+  func installTimeoutTask(_ timeoutTask: Task<Void, Never>) {
+    let shouldCancel = lock.withLock {
+      guard phase == .waiting else { return true }
+      self.timeoutTask = timeoutTask
+      return false
+    }
+    if shouldCancel {
+      timeoutTask.cancel()
+    }
+  }
+
+  func claim() -> Bool {
+    let outcome = lock.withLock { () -> (Bool, Task<Void, Never>?) in
+      guard phase == .waiting else { return (false, nil) }
+      phase = .claimed
+      let pending = self.timeoutTask
+      self.timeoutTask = nil
+      return (true, pending)
+    }
+    guard outcome.0 else { return false }
+    outcome.1?.cancel()
+    return true
+  }
+
+  func finish(with result: Result<Value, any Error>) {
+    let continuation = lock.withLock {
+      guard phase == .claimed else { return nil as CheckedContinuation<Value, any Error>? }
+      phase = .finished
+      cancellation = nil
+      if let continuation = self.continuation {
+        self.continuation = nil
+        return continuation
+      }
+      pendingResult = result
+      return nil
+    }
+    continuation?.resume(with: result)
+  }
+
+  func timeout(with error: RemindCoreError) {
+    abort(with: .failure(error))
+  }
+
+  func cancel() {
+    abort(with: .failure(CancellationError()))
+  }
+
+  private func abort(with result: Result<Value, any Error>) {
+    let outcome = lock.withLock {
+      () -> (
+        CheckedContinuation<Value, any Error>?, AsyncTimeout.Cancellation?, Task<Void, Never>?
+      )? in
+      guard phase == .waiting else { return nil }
+      phase = .finished
+      shouldCancelOperation = true
+      let continuation = self.continuation
+      self.continuation = nil
+      if continuation == nil {
+        pendingResult = result
+      }
+      let cancellation = self.cancellation
+      self.cancellation = nil
+      let timeoutTask = self.timeoutTask
+      self.timeoutTask = nil
+      return (continuation, cancellation, timeoutTask)
+    }
+    guard let outcome else { return }
+    outcome.2?.cancel()
+    outcome.1?()
+    outcome.0?.resume(with: result)
+  }
+}

--- a/Sources/RemindCore/AsyncTimeout.swift
+++ b/Sources/RemindCore/AsyncTimeout.swift
@@ -48,10 +48,10 @@ enum AsyncTimeout {
     }
   }
 
-  nonisolated(nonsending) static func withTimeout<Value: Sendable>(
+  static func withTimeout<Value: Sendable>(
     after duration: Duration,
     timeoutError: RemindCoreError,
-    start: (Completion<Value>) -> Cancellation?
+    start: @Sendable (Completion<Value>) -> Cancellation?
   ) async throws -> Value {
     let state = AsyncTimeoutState<Value>()
 

--- a/Sources/RemindCore/EventKitLocation.swift
+++ b/Sources/RemindCore/EventKitLocation.swift
@@ -1,0 +1,70 @@
+import CoreLocation
+import EventKit
+
+extension RemindersStore {
+  func locationAlarm(from trigger: LocationTrigger) async throws -> EKAlarm {
+    let structuredLocation = EKStructuredLocation(title: trigger.address)
+    let location: CLLocation
+    if let latitude = trigger.latitude, let longitude = trigger.longitude {
+      location = CLLocation(latitude: latitude, longitude: longitude)
+    } else {
+      let request = GeocodeCancellation()
+      let placemarks: [CLPlacemark] = try await AsyncTimeout.withTimeout(
+        after: Self.externalOperationTimeout,
+        timeoutError: .operationFailed("Timed out geocoding location after 30 seconds")
+      ) { completion in
+        let task = Task {
+          do {
+            let placemarks = try await request.geocoder.geocodeAddressString(trigger.address)
+            completion.resume(returning: placemarks)
+          } catch {
+            completion.resume(throwing: error)
+          }
+        }
+        request.install(task)
+        return { request.cancel() }
+      }
+      guard let geocodedLocation = placemarks.first?.location else {
+        throw RemindCoreError.operationFailed("Could not geocode location: \(trigger.address)")
+      }
+      location = geocodedLocation
+    }
+
+    structuredLocation.geoLocation = location
+    structuredLocation.radius = trigger.radius
+
+    let alarm = EKAlarm()
+    alarm.structuredLocation = structuredLocation
+    alarm.proximity = trigger.proximity == .arriving ? .enter : .leave
+    return alarm
+  }
+
+  static func locationTrigger(from reminder: EKReminder) -> LocationTrigger? {
+    guard let alarm = reminder.alarms?.first(where: { $0.structuredLocation != nil }),
+      let structuredLocation = alarm.structuredLocation,
+      let proximity = LocationProximity(eventKitProximity: alarm.proximity)
+    else { return nil }
+
+    let coordinate = structuredLocation.geoLocation?.coordinate
+    return LocationTrigger(
+      address: structuredLocation.title ?? "",
+      latitude: coordinate?.latitude,
+      longitude: coordinate?.longitude,
+      radius: structuredLocation.radius,
+      proximity: proximity
+    )
+  }
+}
+
+extension LocationProximity {
+  fileprivate init?(eventKitProximity: EKAlarmProximity) {
+    switch eventKitProximity {
+    case .enter:
+      self = .arriving
+    case .leave:
+      self = .leaving
+    default:
+      return nil
+    }
+  }
+}

--- a/Sources/RemindCore/EventKitStore.swift
+++ b/Sources/RemindCore/EventKitStore.swift
@@ -1,8 +1,9 @@
-import CoreLocation
 import EventKit
 import Foundation
 
 public actor RemindersStore {
+  static let externalOperationTimeout: Duration = .seconds(30)
+
   private let eventStore = EKEventStore()
   private let calendar: Calendar
 
@@ -72,7 +73,7 @@ public actor RemindersStore {
   }
 
   public func reminders(matching target: ReminderListTarget?) async throws -> [ReminderItem] {
-    await fetchReminders(in: try calendars(matching: target))
+    try await fetchReminders(in: try calendars(matching: target))
   }
 
   public func createList(name: String) async throws -> ReminderList {
@@ -219,7 +220,7 @@ extension RemindersStore {
     }
   }
 
-  private func fetchReminders(in calendars: [EKCalendar]) async -> [ReminderItem] {
+  private func fetchReminders(in calendars: [EKCalendar]) async throws -> [ReminderItem] {
     struct ReminderData: Sendable {
       let id: String
       let title: String
@@ -239,9 +240,13 @@ extension RemindersStore {
       let listName: String
     }
 
-    let reminderData = await withCheckedContinuation { (continuation: CheckedContinuation<[ReminderData], Never>) in
+    let reminderData: [ReminderData] = try await AsyncTimeout.withTimeout(
+      after: Self.externalOperationTimeout,
+      timeoutError: .operationFailed("Timed out waiting for EventKit reminders after 30 seconds")
+    ) { completion in
       let predicate = eventStore.predicateForReminders(in: calendars)
-      eventStore.fetchReminders(matching: predicate) { reminders in
+      let identifier = eventStore.fetchReminders(matching: predicate) { reminders in
+        guard let claim = completion.claim() else { return }
         let data = (reminders ?? []).map { reminder in
           let components = reminder.dueDateComponents
           return ReminderData(
@@ -263,8 +268,10 @@ extension RemindersStore {
             listName: reminder.calendar.title
           )
         }
-        continuation.resume(returning: data)
+        claim.resume(returning: data)
       }
+      let request = EventKitFetchCancellation(eventStore: eventStore, identifier: identifier)
+      return { request.cancel() }
     }
 
     return reminderData.map { data in
@@ -400,43 +407,6 @@ extension RemindersStore {
     return RecurrenceRule(frequency: frequency, interval: rule.interval)
   }
 
-  private func locationAlarm(from trigger: LocationTrigger) async throws -> EKAlarm {
-    let structuredLocation = EKStructuredLocation(title: trigger.address)
-    let location: CLLocation
-    if let latitude = trigger.latitude, let longitude = trigger.longitude {
-      location = CLLocation(latitude: latitude, longitude: longitude)
-    } else {
-      let placemarks = try await CLGeocoder().geocodeAddressString(trigger.address)
-      guard let geocodedLocation = placemarks.first?.location else {
-        throw RemindCoreError.operationFailed("Could not geocode location: \(trigger.address)")
-      }
-      location = geocodedLocation
-    }
-
-    structuredLocation.geoLocation = location
-    structuredLocation.radius = trigger.radius
-
-    let alarm = EKAlarm()
-    alarm.structuredLocation = structuredLocation
-    alarm.proximity = trigger.proximity == .arriving ? .enter : .leave
-    return alarm
-  }
-
-  private static func locationTrigger(from reminder: EKReminder) -> LocationTrigger? {
-    guard let alarm = reminder.alarms?.first(where: { $0.structuredLocation != nil }),
-      let structuredLocation = alarm.structuredLocation,
-      let proximity = LocationProximity(eventKitProximity: alarm.proximity)
-    else { return nil }
-
-    let coordinate = structuredLocation.geoLocation?.coordinate
-    return LocationTrigger(
-      address: structuredLocation.title ?? "",
-      latitude: coordinate?.latitude,
-      longitude: coordinate?.longitude,
-      radius: structuredLocation.radius,
-      proximity: proximity
-    )
-  }
 }
 
 extension RecurrenceFrequency {
@@ -472,18 +442,5 @@ extension RecurrenceFrequency {
 extension RecurrenceRule {
   fileprivate var eventKitFrequency: EKRecurrenceFrequency {
     frequency.eventKitFrequency
-  }
-}
-
-extension LocationProximity {
-  fileprivate init?(eventKitProximity: EKAlarmProximity) {
-    switch eventKitProximity {
-    case .enter:
-      self = .arriving
-    case .leave:
-      self = .leaving
-    default:
-      return nil
-    }
   }
 }

--- a/Sources/RemindCore/EventKitStore.swift
+++ b/Sources/RemindCore/EventKitStore.swift
@@ -240,12 +240,13 @@ extension RemindersStore {
       let listName: String
     }
 
+    let context = EventKitFetchContext(eventStore: eventStore, calendars: calendars)
     let reminderData: [ReminderData] = try await AsyncTimeout.withTimeout(
       after: Self.externalOperationTimeout,
       timeoutError: .operationFailed("Timed out waiting for EventKit reminders after 30 seconds")
     ) { completion in
-      let predicate = eventStore.predicateForReminders(in: calendars)
-      let identifier = eventStore.fetchReminders(matching: predicate) { reminders in
+      let predicate = context.eventStore.predicateForReminders(in: context.calendars)
+      let identifier = context.eventStore.fetchReminders(matching: predicate) { reminders in
         guard let claim = completion.claim() else { return }
         let data = (reminders ?? []).map { reminder in
           let components = reminder.dueDateComponents
@@ -270,7 +271,7 @@ extension RemindersStore {
         }
         claim.resume(returning: data)
       }
-      let request = EventKitFetchCancellation(eventStore: eventStore, identifier: identifier)
+      let request = EventKitFetchCancellation(eventStore: context.eventStore, identifier: identifier)
       return { request.cancel() }
     }
 

--- a/Sources/RemindCore/SystemOperationCancellation.swift
+++ b/Sources/RemindCore/SystemOperationCancellation.swift
@@ -2,6 +2,16 @@ import CoreLocation
 import EventKit
 import Foundation
 
+final class EventKitFetchContext: @unchecked Sendable {
+  let eventStore: EKEventStore
+  let calendars: [EKCalendar]
+
+  init(eventStore: EKEventStore, calendars: [EKCalendar]) {
+    self.eventStore = eventStore
+    self.calendars = calendars
+  }
+}
+
 final class EventKitFetchCancellation: @unchecked Sendable {
   private let eventStore: EKEventStore
   private let identifier: Any

--- a/Sources/RemindCore/SystemOperationCancellation.swift
+++ b/Sources/RemindCore/SystemOperationCancellation.swift
@@ -1,0 +1,47 @@
+import CoreLocation
+import EventKit
+import Foundation
+
+final class EventKitFetchCancellation: @unchecked Sendable {
+  private let eventStore: EKEventStore
+  private let identifier: Any
+
+  init(eventStore: EKEventStore, identifier: Any) {
+    self.eventStore = eventStore
+    self.identifier = identifier
+  }
+
+  func cancel() {
+    eventStore.cancelFetchRequest(identifier)
+  }
+}
+
+final class GeocodeCancellation: @unchecked Sendable {
+  let geocoder = CLGeocoder()
+
+  private let lock = NSLock()
+  private var task: Task<Void, Never>?
+  private var isCancelled = false
+
+  func install(_ task: Task<Void, Never>) {
+    let shouldCancel = lock.withLock {
+      guard !isCancelled else { return true }
+      self.task = task
+      return false
+    }
+    if shouldCancel {
+      task.cancel()
+    }
+  }
+
+  func cancel() {
+    let task = lock.withLock {
+      isCancelled = true
+      let pending = self.task
+      self.task = nil
+      return pending
+    }
+    task?.cancel()
+    geocoder.cancelGeocode()
+  }
+}

--- a/Tests/RemindCoreTests/AsyncTimeoutTests.swift
+++ b/Tests/RemindCoreTests/AsyncTimeoutTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Testing
+
+@testable import RemindCore
+
+private final class TestSignal: @unchecked Sendable {
+  private let lock = NSLock()
+  private var continuation: CheckedContinuation<Void, Never>?
+  private var isRaised = false
+
+  var raised: Bool {
+    lock.withLock { isRaised }
+  }
+
+  func wait() async {
+    await withCheckedContinuation { continuation in
+      let resumeImmediately = lock.withLock {
+        if isRaised {
+          return true
+        }
+        self.continuation = continuation
+        return false
+      }
+      if resumeImmediately {
+        continuation.resume()
+      }
+    }
+  }
+
+  func raise() {
+    let continuation = lock.withLock {
+      isRaised = true
+      let pending = self.continuation
+      self.continuation = nil
+      return pending
+    }
+    continuation?.resume()
+  }
+}
+
+struct AsyncTimeoutTests {
+  @Test("Returns when the operation finishes before the deadline")
+  func operationWins() async throws {
+    let cancelled = TestSignal()
+    let value = try await AsyncTimeout.withTimeout(
+      after: .seconds(1),
+      timeoutError: .operationFailed("timed out")
+    ) { completion in
+      completion.resume(returning: "ok")
+      return { cancelled.raise() }
+    }
+
+    #expect(value == "ok")
+    #expect(!cancelled.raised)
+  }
+
+  @Test("Cancels the operation and returns when the deadline wins")
+  func deadlineWins() async {
+    let cancelled = TestSignal()
+
+    await #expect(throws: RemindCoreError.operationFailed("timed out")) {
+      try await AsyncTimeout.withTimeout(
+        after: .milliseconds(20),
+        timeoutError: .operationFailed("timed out")
+      ) { _ in
+        { cancelled.raise() }
+      } as String
+    }
+
+    #expect(cancelled.raised)
+  }
+
+  @Test("A claimed callback remains successful while it converts its result")
+  func claimedCallbackWinsBeforeConversion() async throws {
+    let cancelled = TestSignal()
+    let value: String = try await AsyncTimeout.withTimeout(
+      after: .milliseconds(20),
+      timeoutError: .operationFailed("timed out")
+    ) { completion in
+      let claim = completion.claim()
+      Task {
+        try await Task.sleep(for: .milliseconds(50))
+        claim?.resume(returning: "converted")
+      }
+      return { cancelled.raise() }
+    }
+
+    #expect(value == "converted")
+    #expect(!cancelled.raised)
+  }
+
+  @Test("Caller cancellation cancels the operation")
+  func callerCancellation() async {
+    let started = TestSignal()
+    let cancelled = TestSignal()
+    let task = Task {
+      try await AsyncTimeout.withTimeout(
+        after: .seconds(10),
+        timeoutError: .operationFailed("timed out")
+      ) { _ in
+        started.raise()
+        return { cancelled.raise() }
+      } as String
+    }
+
+    await started.wait()
+    task.cancel()
+    await #expect(throws: CancellationError.self) {
+      try await task.value
+    }
+    #expect(cancelled.raised)
+  }
+
+  @Test("Late operation results are ignored after the deadline")
+  func lateResultIsIgnored() async {
+    let released = TestSignal()
+
+    await #expect(throws: RemindCoreError.operationFailed("timed out")) {
+      try await AsyncTimeout.withTimeout(
+        after: .milliseconds(20),
+        timeoutError: .operationFailed("timed out")
+      ) { completion in
+        Task {
+          await released.wait()
+          completion.resume(returning: "late")
+        }
+        return { released.raise() }
+      } as String
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -10,7 +10,7 @@ mkdir -p "${CACHE_PATH}"
 
 MIN_COVERAGE="${COVERAGE_MIN:-90}"
 INCLUDE_REGEX="${COVERAGE_INCLUDE_REGEX:-/Sources/RemindCore/}"
-EXCLUDE_REGEX="${COVERAGE_EXCLUDE_REGEX:-/Sources/RemindCore/EventKitStore.swift}"
+EXCLUDE_REGEX="${COVERAGE_EXCLUDE_REGEX:-/Sources/RemindCore/(EventKitStore|EventKitLocation|SystemOperationCancellation)\\.swift}"
 
 echo "==> swift test --enable-code-coverage (isolated build dir)"
 swift test --enable-code-coverage --build-path "${COVERAGE_BUILD_PATH}" --cache-path "${CACHE_PATH}" >/dev/null


### PR DESCRIPTION
## Summary

Consolidates #66 and #67 around one timeout contract instead of landing two independently invented races.

- bound EventKit reminder fetches and Core Location geocoding to 30 seconds
- claim EventKit callback ownership before synchronous reminder conversion
- cancel the underlying EventKit fetch or geocoder on deadline and caller cancellation
- surface both deadlines as `RemindCoreError.operationFailed`
- update Commander 0.2.2 to 0.2.4 and add the pnpm lockfile

The implementation credits Sebastien Tardif for both original fixes and Vincent Koc for the substantive geocoder race follow-up.

## Verification

`make check`

```text
78 tests in 23 suites passed
Coverage (lines): 91.9% (855/930)
Min: 90.0%
```

Signed release build:

```text
$ pnpm build
Build of product 'remindctl' complete!
$ codesign --verify --strict --verbose=2 bin/remindctl
bin/remindctl: valid on disk
bin/remindctl: satisfies its Designated Requirement
```

Real EventKit and Core Location normal path, with output limited to the synthetic fixture:

```text
$ ./bin/remindctl all --json | jq '{eventKitReminderCount: length}'
{
  "eventKitReminderCount": 7
}

$ ./bin/remindctl add "remindctl timeout live proof 2026-08-09" --location "1 Apple Park Way, Cupertino, CA" --json
{
  "title": "remindctl timeout live proof 2026-08-09",
  "locationTrigger": {
    "address": "1 Apple Park Way, Cupertino, CA",
    "latitude": 37.334859,
    "longitude": -122.0090403,
    "proximity": "arriving",
    "radius": 100
  }
}

$ ./bin/remindctl info <fixture-id> --json
<same location trigger>
$ ./bin/remindctl delete <fixture-id> --force
Deleted 1 reminder(s)
```

Deadline proof used the same signed CLI after temporarily changing the single shared duration from 30 seconds to zero, then restored 30 seconds and rebuilt the final artifact:

```text
$ ./bin/remindctl all --json
Timed out waiting for EventKit reminders after 30 seconds
exit=1

$ ./bin/remindctl add "remindctl zero-deadline proof 2026-08-09" --location "1 Apple Park Way, Cupertino, CA" --json
Timed out geocoding location after 30 seconds
exit=1
```

Cleanup verification:

```text
normalFixtureRemaining: 0
timeoutFixtureRemaining: 0
```

Structured pre-commit review completed with no accepted/actionable findings.
