### PR TITLE
fix(ci): restrict workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-15


### PR DESCRIPTION
## Summary

- restrict the CI workflow token to read-only repository contents
- remove reliance on GitHub's broader implicit token defaults

## CodeQL

- resolves [alert #1](https://github.com/openclaw/remindctl/security/code-scanning/1)

## Testing

- `actionlint .github/workflows/ci.yml`
- `git diff --check origin/main...HEAD`
